### PR TITLE
Unifying username and password to "admin=admin" in fabric-camel-demo

### DIFF
--- a/fabric/fabric-examples/fabric-camel-demo/src/main/resources/OSGI-INF/blueprint/fabric-camel-demo.xml
+++ b/fabric/fabric-examples/fabric-camel-demo/src/main/resources/OSGI-INF/blueprint/fabric-camel-demo.xml
@@ -23,8 +23,8 @@
 
     <cm:property-placeholder id="placeholder" persistent-id="org.fusesource.fabric.example.camel" update-strategy="reload">
         <cm:default-properties>
-            <cm:property name="username" value="karaf" />
-            <cm:property name="password" value="karaf" />
+            <cm:property name="username" value="admin" />
+            <cm:property name="password" value="admin" />
         </cm:default-properties>
     </cm:property-placeholder>
 


### PR DESCRIPTION
In fabric-camel-demo there is still old "karaf" username and password.
It would be great to have it unified to "admin".
