### PR TITLE
Don't use sudo for a simple echo

### DIFF
--- a/fabric/fabric-core/src/main/resources/org/fusesource/fabric/internal/install_telnet.sh
+++ b/fabric/fabric-core/src/main/resources/org/fusesource/fabric/internal/install_telnet.sh
@@ -1,7 +1,7 @@
 function install_telnet() {
   echo "Checking if telnet is present."
   if which telnet &> /dev/null; then
-    sudo echo "Telnet is already installed."
+    echo "Telnet is already installed."
   else
     echo "Installing telnet."
     if which dpkg &> /dev/null; then


### PR DESCRIPTION
Removes an unnecessary  invocation of 'sudo' for an 'echo' command.
