### PR TITLE
ProfilePartitionListener does not delete profiles

### DIFF
--- a/fabric/fabric-partition/src/main/java/org/fusesource/fabric/partition/internal/profile/ProfilePartitionListener.java
+++ b/fabric/fabric-partition/src/main/java/org/fusesource/fabric/partition/internal/profile/ProfilePartitionListener.java
@@ -136,7 +136,6 @@ public final class ProfilePartitionListener extends AbstractComponent implements
             Profile toBeRemoved = fabricService.get().getVersion(version.getId()).getProfile(profileId);
             current.removeProfiles(toBeRemoved);
             assignedPartitons.remove(taskDefinition, partition);
-            toBeRemoved.delete();
         }
     }
 


### PR DESCRIPTION
Try to prevent git conflicts that can happen if a container tries to modify a profile while an other tries to delete that.
