### PR TITLE
#392: Fix secure http contexts so that they return nicer errors

### DIFF
--- a/fabric/fabric-git-server/src/main/java/org/fusesource/fabric/git/http/GitHttpServerRegistrationHandler.java
+++ b/fabric/fabric-git-server/src/main/java/org/fusesource/fabric/git/http/GitHttpServerRegistrationHandler.java
@@ -156,7 +156,7 @@ public final class GitHttpServerRegistrationHandler extends AbstractComponent im
     private void registerServlet() {
         try {
             HttpContext base = httpService.get().createDefaultHttpContext();
-            HttpContext secure = new SecureHttpContext(base, realm, role);
+            HttpContext secure = new GitSecureHttpContext(base, realm, role);
 
             File fabricRoot = new File(FABRIC_REPO_PATH);
 

--- a/fabric/fabric-git-server/src/main/java/org/fusesource/fabric/git/http/GitSecureHttpContext.java
+++ b/fabric/fabric-git-server/src/main/java/org/fusesource/fabric/git/http/GitSecureHttpContext.java
@@ -40,9 +40,9 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
 
-public class SecureHttpContext implements HttpContext {
+public class GitSecureHttpContext implements HttpContext {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SecureHttpContext.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GitSecureHttpContext.class);
 
     private static final String HEADER_WWW_AUTHENTICATE = "WWW-Authenticate";
     private static final String HEADER_AUTHORIZATION = "Authorization";
@@ -55,7 +55,7 @@ public class SecureHttpContext implements HttpContext {
     /**
      * Constructor
      */
-    public SecureHttpContext(HttpContext base, String realm, String role) {
+    public GitSecureHttpContext(HttpContext base, String realm, String role) {
         this.base = base;
         this.realm = realm;
         this.role = role;
@@ -168,9 +168,7 @@ public class SecureHttpContext implements HttpContext {
         // request authentication
         try {
             response.setHeader(HEADER_WWW_AUTHENTICATE, AUTHENTICATION_SCHEME_BASIC + " realm=\"" + this.realm + "\"");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentLength(0);
-            response.flushBuffer();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         } catch (IOException ioe) {
             // failed sending the response ... cannot do anything about it
         }

--- a/fabric/fabric-jolokia/src/main/java/org/fusesource/fabric/jolokia/JolokiaSecureHttpContext.java
+++ b/fabric/fabric-jolokia/src/main/java/org/fusesource/fabric/jolokia/JolokiaSecureHttpContext.java
@@ -169,9 +169,7 @@ public class JolokiaSecureHttpContext implements HttpContext, ManagedService {
         // request authentication
         try {
             response.setHeader(HEADER_WWW_AUTHENTICATE, AUTHENTICATION_SCHEME_BASIC + " realm=\"" + this.realm + "\"");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentLength(0);
-            response.flushBuffer();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         } catch (IOException ioe) {
             // failed sending the response ... cannot do anything about it
         }

--- a/fabric/fabric-maven-proxy/src/main/java/org/fusesource/fabric/maven/impl/MavenSecureHttpContext.java
+++ b/fabric/fabric-maven-proxy/src/main/java/org/fusesource/fabric/maven/impl/MavenSecureHttpContext.java
@@ -170,9 +170,7 @@ public class MavenSecureHttpContext implements HttpContext {
         // request authentication
         try {
             response.setHeader(HEADER_WWW_AUTHENTICATE, AUTHENTICATION_SCHEME_BASIC + " realm=\"" + this.realm + "\"");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentLength(0);
-            response.flushBuffer();
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
         } catch (IOException ioe) {
             // failed sending the response ... cannot do anything about it
         }


### PR DESCRIPTION
And also avoid going through other servlet handlers, as the response is not committed.
Rename SecureContext to GitSecureContext for homogeneity
