### PR TITLE
Update to latest version on Apache.NMS.ActiveMQ 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@
         <zookeeper-version>3.4.5</zookeeper-version>
 
         <activemqcpp.version>3.8.2</activemqcpp.version>
-        <activemqnms.version>1.6.1</activemqnms.version>
+        <activemqnms.version>1.6.2</activemqnms.version>
         <qpid-jms-version>0.24</qpid-jms-version>
 
         <felix.obr.version>1.6.6</felix.obr.version>


### PR DESCRIPTION
Updated version property to point to v1.6.2 or Apache.NMS.ActiveMQ
