### PR TITLE
Fixed SAP component build

### DIFF
--- a/components/camel-sap/camel-sap-component/pom.xml
+++ b/components/camel-sap/camel-sap-component/pom.xml
@@ -29,7 +29,7 @@
 	<artifactId>camel-sap</artifactId>
 	<packaging>bundle</packaging>
 
-	<name>[TODO]JBoss Fuse :: Components :: SAP JCO :: Camel Component</name>
+	<name>JBoss Fuse :: Components :: SAP JCO :: Camel Component</name>
 	<url>http://fusesource.org</url>
 
 	<properties>
@@ -54,7 +54,7 @@
 			org.fusesource.camel.component.sap.*;-split-package:=merge-first
 		</fuse.osgi.private.pkg>
 		<fuse.osgi.services.export>org.apache.camel.spi.ComponentResolver;component=sap</fuse.osgi.services.export>
-		 
+		<native.lib.directory>${project.build.directory}/jni</native.lib.directory>
 		<!-- Temporary Overrides for testing 
 		<camel-version>2.12.0</camel-version>
 		<karaf-version>2.3.3</karaf-version>
@@ -141,6 +141,10 @@
 			<artifactId>hamcrest-library</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-integration</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
 			<version>1.5.1</version>
@@ -201,7 +205,76 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-dependency-plugin</artifactId>
+            	<executions>
+            		<execution>
+            			<id>copy-native-lib-for-unit-tests</id>
+            			<phase>process-test-resources</phase>
+            			<goals>
+            				<goal>copy</goal>
+            			</goals>
+            			<configuration>
+            				<stripVersion>true</stripVersion>
+            				<outputDirectory>${native.lib.directory}</outputDirectory>
+            				<artifactItems>
+            					<artifactItem>
+            						<groupId>com.sap.conn.jco</groupId>
+            						<artifactId>sapjco3</artifactId>
+            						<type>${envType}</type>
+            						<classifier>${envClassifier}</classifier>
+            						<overWrite>true</overWrite>
+            						<destFileName>${native.lib.filename}.${envType}</destFileName>
+            					</artifactItem>
+            				</artifactItems>
+            			</configuration>
+            		</execution>
+            	</executions>
+            </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-surefire-plugin</artifactId>
+            	<configuration>
+            		<argLine>-Djava.library.path=${native.lib.directory}</argLine>
+            	</configuration>
+            </plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.apache.maven.plugins
+										</groupId>
+										<artifactId>
+											maven-dependency-plugin
+										</artifactId>
+										<versionRange>
+											[2.1,)
+										</versionRange>
+										<goals>
+											<goal>copy</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 </project>

--- a/components/camel-sap/org.fusesource.camel.component.sap.model.edit/META-INF/MANIFEST.MF
+++ b/components/camel-sap/org.fusesource.camel.component.sap.model.edit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.fusesource.camel.component.sap.model.edit;singleton:=true
-Bundle-Version: 7.3.0.redhat-qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.fusesource.camel.component.sap.model.rfc.provider.SAPRFCEditPlugin$Implementation
 Bundle-Vendor: %providerName

--- a/components/camel-sap/org.fusesource.camel.component.sap.model.edit/pom.xml
+++ b/components/camel-sap/org.fusesource.camel.component.sap.model.edit/pom.xml
@@ -41,5 +41,5 @@
     </plugins>
   </build>
   <url>http://www.fusesource.org</url>
-  <name>[TODO]Camel SAP Component Edit Plugin</name>
+  <name>Camel SAP Component Edit Plugin</name>
 </project>

--- a/components/camel-sap/org.fusesource.camel.component.sap.model/META-INF/MANIFEST.MF
+++ b/components/camel-sap/org.fusesource.camel.component.sap.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.fusesource.camel.component.sap.model;singleton:=true
-Bundle-Version: 7.3.0.redhat-qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/components/camel-sap/org.fusesource.camel.component.sap.model/pom.xml
+++ b/components/camel-sap/org.fusesource.camel.component.sap.model/pom.xml
@@ -40,7 +40,7 @@
   	<version>1.0.0-SNAPSHOT</version>
   </parent>
   <url>http://www.fusesource.org</url>
-  <name>[TODO]Camel SAP Component Model Plugin</name>
+  <name>Camel SAP Component Model Plugin</name>
   <description>Builds Camel SAP Component Model</description>
   <organization>
   	<name>Red Hat, Inc.</name>

--- a/components/camel-sap/org.fusesource.camel.component.sap/META-INF/MANIFEST.MF
+++ b/components/camel-sap/org.fusesource.camel.component.sap/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SAP
 Bundle-SymbolicName: org.fusesource.camel.component.sap
-Bundle-Version: 7.3.0.redhat-qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.fusesource.camel.component.sap.Activator
 Bundle-Vendor: http://www.fusesource.org
 Require-Bundle: org.eclipse.core.runtime,

--- a/components/camel-sap/org.fusesource.camel.component.sap/pom.xml
+++ b/components/camel-sap/org.fusesource.camel.component.sap/pom.xml
@@ -26,7 +26,7 @@
 	</parent>
 
 	<packaging>eclipse-plugin</packaging>
-	<name>[TODO]Camel SAP Component Plugin</name>
+	<name>Camel SAP Component Plugin</name>
 	<description>Builds Camel SAP Plugin</description>
 
 	<organization>

--- a/components/camel-sap/pom.xml
+++ b/components/camel-sap/pom.xml
@@ -28,7 +28,7 @@
 	<artifactId>camel-sap-parent</artifactId>
 	<packaging>pom</packaging>
 
-    <name>[TODO]JBoss Fuse :: Components :: SAP JCO</name>
+    <name>JBoss Fuse :: Components :: SAP JCO</name>
 	<url>http://www.fusesource.org</url>
 
 	<properties>
@@ -97,6 +97,14 @@
 				<artifactId>sapjco3</artifactId>
 				<version>3.0.8</version>
 			</dependency>
+			<dependency>
+				<groupId>com.sap.conn.jco</groupId>
+				<artifactId>sapjco3</artifactId>
+				<version>3.0.8</version>
+				<type>${envType}</type>
+				<classifier>${envClassifier}</classifier>
+				<scope>test</scope>
+			</dependency>
 
 			<dependency>
 				<groupId>org.mockito</groupId>
@@ -110,22 +118,78 @@
 				<version>1.1</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>hamcrest-integration</artifactId>
+				<version>1.1</version>
+				<scope>test</scope>
+			</dependency>
 
 		</dependencies>
 	</dependencyManagement>
-<!-- 
 	<profiles>
 		<profile>
-			<id>linux-amd64</id>
+			<id>integration-tests</id>
+			<properties>
+				<skip.integration.tests>false</skip.integration.tests>
+				<skip.unit.tests>true</skip.unit.tests>
+			</properties>
+		</profile>
+		<profile>
+			<id>win-x86</id>
 			<activation>
 				<os>
-					<name>linux</name>
+					<name>windows</name>
+					<arch>x86</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-i686</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>win-x86_64</id>
+			<activation>
+				<os>
+					<name>windows</name>
+					<arch>x86_64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>win-x86_64</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>win32-amd64</id>
+			<activation>
+				<os>
+					<name>windows</name>
 					<arch>amd64</arch>
 				</os>
 			</activation>
-			<modules>
-				<module>com.sap.conn.jco.linux.x86_64</module>
-			</modules>
+			<properties>
+				<envClassifier>win-x86_64</envClassifier>
+				<envType>dll</envType>
+				<native.lib.filename>sapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>linux-x86</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>x86</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>linux-i686</envClassifier>
+				<envType>so</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
 		</profile>
 		<profile>
 			<id>linux-x86_64</id>
@@ -135,9 +199,39 @@
 					<arch>x86_64</arch>
 				</os>
 			</activation>
-			<modules>
-				<module>com.sap.conn.jco.linux.x86_64</module>
-			</modules>
+			<properties>
+				<envClassifier>linux-x86_64</envClassifier>
+				<envType>so</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>linux-amd64</id>
+			<activation>
+				<os>
+					<name>linux</name>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>linux-x86_64</envClassifier>
+				<envType>so</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>macosx-x86</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+					<arch>x86</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>macosx-i686</envClassifier>
+				<envType>jnilib</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
 		</profile>
 		<profile>
 			<id>macosx-x86_64</id>
@@ -147,13 +241,27 @@
 					<arch>x86_64</arch>
 				</os>
 			</activation>
-			<modules>
-				<module>com.sap.conn.jco.osx.x86_64</module>
-			</modules>
+			<properties>
+				<envClassifier>macosx-x86_64</envClassifier>
+				<envType>jnilib</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
+		</profile>
+		<profile>
+			<id>macosx-amd64</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<envClassifier>macosx-x86_64</envClassifier>
+				<envType>jnilib</envType>
+				<native.lib.filename>libsapjco3</native.lib.filename>
+			</properties>
 		</profile>
 	</profiles>
- -->
- 
 	<build>
 		<pluginManagement>
 			<plugins>

--- a/components/examples/camel-example-sap/pom.xml
+++ b/components/examples/camel-example-sap/pom.xml
@@ -29,7 +29,7 @@
 	<artifactId>camel-example-sap</artifactId>
 	<packaging>bundle</packaging>
 
-	<name>[TODO]Camel SAP Example</name>
+	<name>Camel SAP Example</name>
 	<url>http://www.myorganization.org</url>
 
 	<properties>

--- a/components/examples/pom.xml
+++ b/components/examples/pom.xml
@@ -28,7 +28,7 @@
 	<artifactId>component-examples</artifactId>
 	<packaging>pom</packaging>
 
-    <name>[TODO]JBoss Fuse :: Camel Components :: Examples</name>
+    <name>JBoss Fuse :: Camel Components :: Examples</name>
 	<description>Builds Fuse Component Examples</description>
 	<url>http://www.fusesource.org</url>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -23,7 +23,7 @@
   </parent>
   <artifactId>components</artifactId>
   <packaging>pom</packaging>
-  <name>[TODO]JBoss Fuse :: Components</name>
+  <name>JBoss Fuse :: Components</name>
   <description>Builds Fuse Camel Components</description>
   <url>http://www.fusesource.org</url>
 
@@ -46,12 +46,9 @@
       	</dependency>
       </dependencies>
       <repositories>
-<!--
-    TODO not sure what this is now?
-
 		<repository>
 			<id>fusesource-third-party-internal</id>
-			<url>https://repo.fusesource.com/nexus/content/repositories/maven2-all/</url>
+			<url>https://repository.jboss.org/nexus/content/repositories/fs-maven2-all/</url>
 			<layout>default</layout>
 			<snapshots>
 				<enabled>true</enabled>
@@ -60,8 +57,13 @@
 				<enabled>true</enabled>
 			</releases>
 		</repository>
--->
       </repositories>
+    </profile>
+    <profile>
+    	<id>component-examples</id>
+    	<modules>
+    		<module>examples</module>
+    	</modules>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
- Updated URL for fusesource-third-party-internal repo
- Fixed unit test configuration of camel component to pick
  up required native lib which enable unit tests to run
- Added profile to select component examples for build
- Updated version in eclipse plugin manifests to comply with maven
  version

The native SAP libraries required by SAP camel component unit tests for 32 and 64 bit versions of Linux, Window and Mac OSX have been deployed to the Fusesource Releases 3rd Party (internal, obsolete) repository.
