### PR TITLE
#583: Fixed WARN in child containers when connecting to it from hawtio -...

### DIFF
--- a/fabric/fabric-git-server/src/main/java/io/fabric8/git/http/GitSecureHttpContext.java
+++ b/fabric/fabric-git-server/src/main/java/io/fabric8/git/http/GitSecureHttpContext.java
@@ -111,7 +111,10 @@ public class GitSecureHttpContext implements HttpContext {
         // request authentication
         try {
             response.setHeader(HEADER_WWW_AUTHENTICATE, AUTHENTICATION_SCHEME_BASIC + " realm=\"" + this.realm + "\"");
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            // must response with status and flush as Jetty may report org.eclipse.jetty.server.Response Committed before 401 null
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentLength(0);
+            response.flushBuffer();
         } catch (IOException ioe) {
             // failed sending the response ... cannot do anything about it
         }


### PR DESCRIPTION
... having jetty log every second 2 WARNs aobut - org.eclipse.jetty.server.Response Committed before 401 null
