### PR TITLE
[FABRIC-671] Ensure that the modules refered in basic tests are build be...

### DIFF
--- a/fabric/fabric-itests/basic/pom.xml
+++ b/fabric/fabric-itests/basic/pom.xml
@@ -166,6 +166,34 @@
             <version>${fuse.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.amq</groupId>
+            <artifactId>mq-fabric-camel</artifactId>
+            <version>${fuse.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.fusesource.insight</groupId>
+            <artifactId>insight-camel</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.fusesource.insight</groupId>
+            <artifactId>insight-elasticsearch</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.fusesource.insight</groupId>
+            <artifactId>insight-storage</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         
         <!-- Testing Dependencies -->
         <dependency>

--- a/fabric/fabric-itests/basic/src/test/java/io/fabric8/itests/basic/examples/ExampleCamelClusterTest.java
+++ b/fabric/fabric-itests/basic/src/test/java/io/fabric8/itests/basic/examples/ExampleCamelClusterTest.java
@@ -33,7 +33,6 @@ import scala.actors.threadpool.Arrays;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(AllConfinedStagedReactorFactory.class)
-@Ignore("[FABRIC-671] Fix fabric basic ExampleCamelProfileTest")
 public class ExampleCamelClusterTest extends FabricTestSupport {
 
     @Test

--- a/fabric/fabric-itests/basic/src/test/java/io/fabric8/itests/basic/examples/ExampleCamelProfileTest.java
+++ b/fabric/fabric-itests/basic/src/test/java/io/fabric8/itests/basic/examples/ExampleCamelProfileTest.java
@@ -46,7 +46,6 @@ import scala.actors.threadpool.Arrays;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(AllConfinedStagedReactorFactory.class)
-@Ignore("[FABRIC-847] Fix fabric basic ExampleCamelProfileTest")
 public class ExampleCamelProfileTest extends FabricTestSupport {
 
     @Test


### PR DESCRIPTION
...fore the basic tests. Reenable ExampleCamelClusterTest and ExampleCamelProfileTest
