### PR TITLE
Improved dependency fetching for DeploymentAgentTest

### DIFF
--- a/fabric/fabric-itests/smoke/pom.xml
+++ b/fabric/fabric-itests/smoke/pom.xml
@@ -65,6 +65,15 @@
             <artifactId>httpclient-osgi</artifactId>
             <version>4.1.2</version>
         </dependency>
+
+        <!-- Dependencies for profiles -->
+        <dependency>
+            <groupId>org.fusesource.examples.fabric-camel-dosgi</groupId>
+            <artifactId>features</artifactId>
+            <version>${fabric.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
         
         <!-- Test Dependencies -->
         <dependency>


### PR DESCRIPTION
Hi,

`DeploymentAgentTest` fails if you try to run it without building `fabric-examples/fabric-camel-dosgi` before. This happens because Pax Exam won't download the latest `org.fusesource.examples.fabric-camel-dosgi` SNAPSHOT from the SNAPSHOT repository (Exam is not configured to search in the snapshot repo).

The common workaround for this kind of issues with Exam is to define required dependency in the POM file. Maven will load the latest snapshot before the build and place it in the local repository (available for Exam by default).

Cheers.
