### PR TITLE
Switched scala-tools org to Scala Tools at Sonatype

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -146,7 +146,7 @@ In the following example, I will modify the *io.fabric8.agent* pid and change th
         		 https://repo.fusesource.com/nexus/content/groups/ea,
         		 http://repository.springsource.com/maven/bundles/release,
         		 http://repository.springsource.com/maven/bundles/external,
-        		 http://scala-tools.org/repo-releases
+        		 http://oss.sonatype.org/content/groups/scala-tools
 
 Let's see how we can change the Agent Properties section *(the agent properties is represented by the io.fabric8.agent pid that was mentioned above)*:
 

--- a/esb/esb-assembly/jboss-fuse-full/src/main/filtered-resources/extras/fusecdc/default.profile
+++ b/esb/esb-assembly/jboss-fuse-full/src/main/filtered-resources/extras/fusecdc/default.profile
@@ -158,7 +158,7 @@ repository.4=svn.apache.org
 repository.4.url=http://svn.apache.org/repos/asf/servicemix/m2-repo
 
 repository.5=scala-tools.org
-repository.5.url=http://scala-tools.org/repo-releases
+repository.5.url=http://oss.sonatype.org/content/groups/scala-tools
 
 repository.6=releases.springsource.com
 repository.6.url=http://repository.springsource.com/maven/bundles/release

--- a/esb/shared/src/main/resources/etc/io.fabric8.fab.osgi.url.cfg
+++ b/esb/shared/src/main/resources/etc/io.fabric8.fab.osgi.url.cfg
@@ -50,5 +50,5 @@
 #    http://svn.apache.org/repos/asf/servicemix/m2-repo, \
 #    http://repository.springsource.com/maven/bundles/release, \
 #    http://repository.springsource.com/maven/bundles/external, \
-#    http://scala-tools.org/repo-releases
+#    http://oss.sonatype.org/content/groups/scala-tools
 

--- a/fab/tests/fab-itests/src/test/resources/io.fabric8.fab.osgi.url.cfg
+++ b/fab/tests/fab-itests/src/test/resources/io.fabric8.fab.osgi.url.cfg
@@ -19,7 +19,7 @@ org.ops4j.pax.url.mvn.repositories=\
         http://svn.apache.org/repos/asf/servicemix/m2-repo, \
         http://repository.springsource.com/maven/bundles/release, \
         http://repository.springsource.com/maven/bundles/external, \
-        http://scala-tools.org/repo-releases, \
+        http://oss.sonatype.org/content/groups/scala-tools, \
         https://repo.fusesource.com/nexus/content/groups/public, \
         https://repo.fusesource.com/nexus/content/groups/ea, \
         https://repo.fusesource.com/nexus/content/groups/public-snapshots@snapshots, \

--- a/fabric/fabric-itests/common/src/main/java/io/fabric8/itests/paxexam/support/FabricTestSupport.java
+++ b/fabric/fabric-itests/common/src/main/java/io/fabric8/itests/paxexam/support/FabricTestSupport.java
@@ -177,7 +177,7 @@ public class FabricTestSupport extends FuseTestSupport {
                 + "https://repo.fusesource.com/nexus/content/repositories/snapshots/@snapshots@noreleases,"
                 + "http://repository.apache.org/content/groups/snapshots-group@snapshots@noreleases," + "http://svn.apache.org/repos/asf/servicemix/m2-repo,"
                 + "http://repository.springsource.com/maven/bundles/release," + "http://repository.springsource.com/maven/bundles/external,"
-                + "http://scala-tools.org/repo-releases," + "https://repository.jboss.org/nexus/content/groups/ea" + " default");
+                + "http://oss.sonatype.org/content/groups/scala-tools," + "https://repository.jboss.org/nexus/content/groups/ea" + " default");
     }
 
     protected void waitForFabricCommands() {

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/configs/versions/1.0/profiles/default/io.fabric8.agent.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/configs/versions/1.0/profiles/default/io.fabric8.agent.properties
@@ -29,6 +29,6 @@ org.ops4j.pax.url.mvn.repositories= \
     https://repo.fusesource.com/nexus/content/groups/ea@id=jbossearlyaccess, \
     http://repository.springsource.com/maven/bundles/release@id=ebrreleases, \
     http://repository.springsource.com/maven/bundles/external@id=ebrexternal, \
-    http://scala-tools.org/repo-releases@id=scala
+    http://oss.sonatype.org/content/groups/scala-tools@id=scala
 org.ops4j.pax.url.mvn.defaultRepositories=file:${karaf.home}/${karaf.default.repository}@snapshots@id=karaf-default,\
     file:${karaf.home}/local-repo@snapshots@id=karaf-local

--- a/fabric/fabric8-karaf/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
+++ b/fabric/fabric8-karaf/src/main/resources/etc/org.ops4j.pax.url.mvn.cfg
@@ -95,5 +95,5 @@ org.ops4j.pax.url.mvn.repositories= \
     http://svn.apache.org/repos/asf/servicemix/m2-repo@id=servicemix.repo, \
     http://repository.springsource.com/maven/bundles/release@id=springsource.release.repo, \
     http://repository.springsource.com/maven/bundles/external@id=springsource.external.repo, \
-    http://scala-tools.org/repo-releases@id=scala.repo
+    http://oss.sonatype.org/content/groups/scala-tools@id=scala.repo
 

--- a/insight/insight-log4j/src/main/java/org/fusesource/insight/log/log4j/Log4jLogQuery.java
+++ b/insight/insight-log4j/src/main/java/org/fusesource/insight/log/log4j/Log4jLogQuery.java
@@ -349,7 +349,7 @@ public class Log4jLogQuery extends LogQuerySupport implements Log4jLogQueryMBean
                 "http://svn.apache.org/repos/asf/servicemix/m2-repo@id=servicemix.repo, " +
                 "http://repository.springsource.com/maven/bundles/release@id=springsource.release.repo, " +
                 "http://repository.springsource.com/maven/bundles/external@id=springsource.external.repo, " +
-                "http://scala-tools.org/repo-releases@id=scala.repo");
+                "http://oss.sonatype.org/content/groups/scala-tools@id=scala.repo");
         return defaultProperties;
     }
 

--- a/sandbox/stream/fabric-bridge-zookeeper/src/test/resources/zkexport/fabric/configs/versions/1.0/profiles/default/org.fusesource.fabric.agent.properties.cfg
+++ b/sandbox/stream/fabric-bridge-zookeeper/src/test/resources/zkexport/fabric/configs/versions/1.0/profiles/default/org.fusesource.fabric.agent.properties.cfg
@@ -4,4 +4,4 @@ feature.fabric-agent=fabric-agent
 repository.fabric=mvn\:io.fabric8/fabric8-karaf/1.1-SNAPSHOT/xml/features
 org.ops4j.pax.url.mvn.defaultRepositories=file\:${karaf.home}/${karaf.default.repository}@snapshots
 feature.karaf=karaf
-org.ops4j.pax.url.mvn.repositories=http\://repo1.maven.org/maven2,http\://repo.fusesource.com/nexus/content/repositories/releases,http\://scala-tools.org/repo-releases,http\://repo.fusesource.com/nexus/content/groups/ea
+org.ops4j.pax.url.mvn.repositories=http\://repo1.maven.org/maven2,http\://repo.fusesource.com/nexus/content/repositories/releases,http\://oss.sonatype.org/content/groups/scala-tools,http\://repo.fusesource.com/nexus/content/groups/ea

--- a/website/src/fabric/docs/fabric-profiles.page
+++ b/website/src/fabric/docs/fabric-profiles.page
@@ -153,7 +153,7 @@ In the following example, I will modify the *io.fabric8.agent* pid and change th
         		 https://repo.fusesource.com/nexus/content/groups/ea,
         		 http://repository.springsource.com/maven/bundles/release,
         		 http://repository.springsource.com/maven/bundles/external,
-        		 http://scala-tools.org/repo-releases
+        		 http://oss.sonatype.org/content/groups/scala-tools
 
 Let's see how we can change the Agent Properties section *(the agent properties is represented by the io.fabric8.agent pid that was mentioned above)*:
 


### PR DESCRIPTION
Hi,

The old Scala Tools repo [1] doesn't serve artifacts anymore. New Sonatype Scala Tools repository [2] should be used instead.

Cheers.

[1] http://scala-tools.org
[2] https://oss.sonatype.org/content/groups/scala-tools
