### PR TITLE
FABRIC-887: fabric-git must use same TCCL when doing git operation as jg...

### DIFF
--- a/esb/esb-itests/basic/src/test/java/org/fusesource/esb/itests/basic/fabric/EsbProfileLongTest.java
+++ b/esb/esb-itests/basic/src/test/java/org/fusesource/esb/itests/basic/fabric/EsbProfileLongTest.java
@@ -24,7 +24,6 @@ import io.fabric8.itests.paxexam.support.ContainerBuilder;
 import java.util.Set;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
@@ -33,7 +32,6 @@ import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(AllConfinedStagedReactorFactory.class)
-@Ignore("[FABRIC-812] Fix esb EsbProfileLongTest")
 public class EsbProfileLongTest extends EsbFeatureTest {
 
     @Test


### PR DESCRIPTION
...it cannot load resources if TCCL changes, and we have a unlucky race-conditon. So use the TCCL that loaded GitDataStore as that TCCL can jgit use to load its resources which is embedded in the same bundle.
