### PR TITLE
Fixed InstallOptions' URL building

### DIFF
--- a/process/process-manager/src/main/java/org/fusesource/process/manager/InstallOptions.java
+++ b/process/process-manager/src/main/java/org/fusesource/process/manager/InstallOptions.java
@@ -238,7 +238,7 @@ public class InstallOptions implements Serializable {
         }
 
         public InstallOptions build() throws MalformedURLException {
-                return new InstallOptions(getName(), url, controllerUrl, extractCmd, offline, optionalDependencyPatterns, excludeDependencyFilterPatterns, mainClass, properties);
+                return new InstallOptions(getName(), getUrl(), controllerUrl, extractCmd, offline, optionalDependencyPatterns, excludeDependencyFilterPatterns, mainClass, properties);
         }
     }
 

--- a/process/process-manager/src/test/java/org/fusesource/process/manager/InstallOptionsTest.java
+++ b/process/process-manager/src/test/java/org/fusesource/process/manager/InstallOptionsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.process.manager;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.fusesource.process.manager.InstallOptions.InstallOptionsBuilder;
+
+public class InstallOptionsTest extends Assert {
+
+    InstallOptions options;
+
+    @Before
+    public void setUp() throws MalformedURLException {
+        System.setProperty("java.protocol.handler.pkgs", "org.ops4j.pax.url");
+        options = new InstallOptionsBuilder().
+                groupId("org.apache.camel").artifactId("camel-core").version("2.12.0").
+                build();
+    }
+
+    @Test
+    public void shouldBuildParametersUrl() throws MalformedURLException {
+        assertNotNull(options.getUrl());
+        assertEquals(new URL("mvn:org.apache.camel/camel-core/2.12.0/jar"), options.getUrl());
+    }
+
+}


### PR DESCRIPTION
Hi,

Installing jar as a process seems to be broken in the latest Fabric. One of the problems I've encoutered is related to the `NullPointerException` being thrown during the jar installation process.

The reason behind the mentioned NPE is the fact that `InstallOptionsBuilder` doesn't calculate URL of the artifact being installed when creating new `InstallOptions` instance. Builder reads the value of `url` field, while it should call `getUrl()` method instead.

I've fixed the issue and attached appropriate unit test.

Cheers.

PS There are some other issues related to the installation of jar via process manager - I'll commit appropriate fixes in the next pull requests.
