### PR TITLE
[Jar installer] Fixed building of dependency graph tree.

### DIFF
--- a/process/process-manager/src/main/java/org/fusesource/process/manager/support/JarInstaller.java
+++ b/process/process-manager/src/main/java/org/fusesource/process/manager/support/JarInstaller.java
@@ -60,7 +60,7 @@ public class JarInstaller {
         // now lets download the executable jar as main.jar and all its dependencies...
         Filter<Dependency> optionalFilter = DependencyFilters.parseExcludeOptionalFilter(join(Arrays.asList(parameters.getOptionalDependencyPatterns()), " "));
         Filter<Dependency> excludeFilter = DependencyFilters.parseExcludeFilter(join(Arrays.asList(parameters.getExcludeDependencyFilterPatterns()), " "), optionalFilter);
-        DependencyTreeResult result = mavenResolver.collectDependencies(getArtifactFile(parameters.getUrl()),
+        DependencyTreeResult result = mavenResolver.collectDependenciesForJar(getArtifactFile(parameters.getUrl()),
                 parameters.isOffline(),
                 excludeFilter);
 

--- a/process/process-manager/src/test/java/org/fusesource/process/manager/support/JarInstallerTest.java
+++ b/process/process-manager/src/test/java/org/fusesource/process/manager/support/JarInstallerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fusesource.process.manager.support;
+
+import java.io.File;
+import java.net.MalformedURLException;
+
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
+import org.fusesource.process.manager.InstallOptions;
+import org.fusesource.process.manager.config.ProcessConfig;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fusesource.process.manager.InstallOptions.InstallOptionsBuilder;
+
+public class JarInstallerTest extends Assert {
+
+    JarInstaller jarInstaller = new JarInstaller(newSingleThreadExecutor());
+
+    File installDir = new File("target", randomUUID().toString());
+
+    InstallOptions installOptions;
+
+    @Before
+    public void setUp() throws MalformedURLException {
+        System.setProperty("java.protocol.handler.pkgs", "org.ops4j.pax.url");
+
+        installOptions = new InstallOptionsBuilder().url("mvn:org.apache.camel/camel-xstream/2.12.0/jar").build();
+    }
+
+    @Test
+    public void shouldInstallJarDependencies() throws Exception {
+        jarInstaller.unpackJarProcess(new ProcessConfig(), 1, installDir, installOptions);
+        assertTrue(new File(installDir, "lib/xstream-1.4.4.jar").exists());
+    }
+
+}


### PR DESCRIPTION
Hi,

This is another issue in the Fabric master that prevents users from installing jar as a managed process. 

`JarInstaller` tries to resolve dependency tree against installed jar's POM, but `File` instance you pass to the resolving method (`mavenResolver#collectDependencies`) represents jar file, not POM file. That results in an attempt to parse JAR input stream with XML parser and error returned to the Karaf shell.

I changed to method used to resolve dependency tree to one taking jar as a parameter (`mavenResolver#collectDependenciesForJar` instead of `mavenResolver#collectDependencies`). After this change the dependency graph tree is properly resolved. Also added appropriate unit test.

Cheers.
