### PR TITLE
[Process manager] InstallOptionsBuilder now gracefully handles nulls.

### DIFF
--- a/process/process-manager/src/main/java/org/fusesource/process/manager/InstallOptions.java
+++ b/process/process-manager/src/main/java/org/fusesource/process/manager/InstallOptions.java
@@ -25,6 +25,8 @@ import java.util.Map;
 
 import com.google.common.base.Strings;
 
+import static com.google.common.base.Objects.firstNonNull;
+
 /**
  * The parameters used to install a jar process
  */
@@ -116,12 +118,12 @@ public class InstallOptions implements Serializable {
         }
 
         public T optionalDependencyPatterns(final String... optionalDependencyPatterns) {
-            this.optionalDependencyPatterns = optionalDependencyPatterns;
+            this.optionalDependencyPatterns = firstNonNull(optionalDependencyPatterns, new String[0]);
             return (T) this;
         }
 
         public T excludeDependencyFilterPatterns(final String... excludeDependencyFilterPatterns) {
-            this.excludeDependencyFilterPatterns = excludeDependencyFilterPatterns;
+            this.excludeDependencyFilterPatterns = firstNonNull(excludeDependencyFilterPatterns, new String[0]);
             return (T) this;
         }
 

--- a/process/process-manager/src/test/java/org/fusesource/process/manager/InstallOptionsTest.java
+++ b/process/process-manager/src/test/java/org/fusesource/process/manager/InstallOptionsTest.java
@@ -34,6 +34,8 @@ public class InstallOptionsTest extends Assert {
         System.setProperty("java.protocol.handler.pkgs", "org.ops4j.pax.url");
         options = new InstallOptionsBuilder().
                 groupId("org.apache.camel").artifactId("camel-core").version("2.12.0").
+                optionalDependencyPatterns(null).
+                excludeDependencyFilterPatterns(null).
                 build();
     }
 
@@ -41,6 +43,18 @@ public class InstallOptionsTest extends Assert {
     public void shouldBuildParametersUrl() throws MalformedURLException {
         assertNotNull(options.getUrl());
         assertEquals(new URL("mvn:org.apache.camel/camel-core/2.12.0/jar"), options.getUrl());
+    }
+
+    @Test
+    public void shouldSetEmptyOptionalDependencyPatterns() {
+        assertNotNull(options.getOptionalDependencyPatterns());
+        assertEquals(0, options.getOptionalDependencyPatterns().length);
+    }
+
+    @Test
+    public void shouldSetEmptyExcludeDependencyFilterPatterns() {
+        assertNotNull(options.getExcludeDependencyFilterPatterns());
+        assertEquals(0, options.getExcludeDependencyFilterPatterns().length);
     }
 
 }


### PR DESCRIPTION
Hi,

In the most recent version of the Fabric users encounter NPE if `optionalDependencyPatterns` and `excludeDependencyFilterPatterns` options of the `process:install-jar` command are not specified at the command line. Described behavior occurs because Karaf command (`InstallJar`) passes null values instead of the empty arrays to the `InstallOptionsBuilder`. 

I changed `InstallOptionsBuilder` so it now gracefully handles `null` values passed to the `optionalDependencyPatterns` and `excludeDependencyFilterPatterns` methods. If null values are passed to these builder methods, I set empty array on the builder.

I could solve this issue on the Karaf command level (`org.fusesource.process.manager.commands.InstallJar` class) or by null-checking in `JarInstaller` class, however I think that making `InstallOptionsBuilder` null-proof will be more beneficial, as would protect us from similar misuse of the builder API.

Cheers.
