### PR TITLE
[Jar installer] Fixed installed jar copying process

### DIFF
--- a/process/process-manager/src/main/java/org/fusesource/process/manager/support/JarInstaller.java
+++ b/process/process-manager/src/main/java/org/fusesource/process/manager/support/JarInstaller.java
@@ -68,7 +68,11 @@ public class JarInstaller {
 
         File libDir = new File(installDir, "lib");
         libDir.mkdirs();
-        File mainJar = getFile(mainJarDependency);
+        Artifact mainPomArtifact = mainJarDependency.getDependency().getArtifact();
+        File mainJar = mavenResolver.resolveArtifact(parameters.isOffline(),
+                mainPomArtifact.getGroupId(), mainPomArtifact.getArtifactId(),
+                mainPomArtifact.getVersion(), mainPomArtifact.getClassifier(), "jar").
+                getFile();
         if (mainJar == null) {
             System.out.println("Cannot find file for main jar " + mainJarDependency);
         } else {

--- a/process/process-manager/src/test/java/org/fusesource/process/manager/support/JarInstallerTest.java
+++ b/process/process-manager/src/test/java/org/fusesource/process/manager/support/JarInstallerTest.java
@@ -18,10 +18,12 @@ package org.fusesource.process.manager.support;
 
 import java.io.File;
 import java.net.MalformedURLException;
+import java.util.jar.Manifest;
 
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 
+import aQute.lib.osgi.Jar;
 import org.fusesource.process.manager.InstallOptions;
 import org.fusesource.process.manager.config.ProcessConfig;
 import org.junit.Assert;
@@ -50,5 +52,16 @@ public class JarInstallerTest extends Assert {
         jarInstaller.unpackJarProcess(new ProcessConfig(), 1, installDir, installOptions);
         assertTrue(new File(installDir, "lib/xstream-1.4.4.jar").exists());
     }
+
+    @Test
+    public void shouldCopyMainJar() throws Exception {
+        // When
+        jarInstaller.unpackJarProcess(new ProcessConfig(), 1, installDir, installOptions);
+
+        // Then
+        Manifest manifest = new Jar(new File(installDir, "lib/main.jar")).getManifest();
+        assertEquals("org.apache.camel.camel-xstream", manifest.getMainAttributes().getValue("Bundle-SymbolicName"));
+    }
+
 
 }


### PR DESCRIPTION
Hi,

The is the last issue I've found while plating with jar process manager. In the latest version of the Fabric users cannot properly start installed jar process, because we copy installed jar's POM file to `lib/main.jar` instead of the real jar file.

I fixed the `JarInstaller` to resolve jar file, not its POM.

Cheers.
