### PR TITLE
Fixed NPE in the Create command (when default data is passed).

### DIFF
--- a/fabric/fabric-zookeeper-commands/pom.xml
+++ b/fabric/fabric-zookeeper-commands/pom.xml
@@ -76,6 +76,12 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fabric/fabric-zookeeper-commands/src/main/java/io/fabric8/zookeeper/commands/Create.java
+++ b/fabric/fabric-zookeeper-commands/src/main/java/io/fabric8/zookeeper/commands/Create.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.util.List;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.BackgroundPathAndBytesable;
 import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
@@ -79,7 +80,12 @@ public class Create extends ZooKeeperCommandSupport {
             if (recursive) {
                 curator.create().creatingParentsIfNeeded().withMode(mode).withACL(acls).forPath(path, nodeData.getBytes());
             } else {
-                curator.create().withMode(mode).withACL(acls).forPath(path, nodeData.getBytes());
+                BackgroundPathAndBytesable<String> create = curator.create().withMode(mode).withACL(acls);
+                if (nodeData == null) {
+                    create.forPath(path);
+                } else {
+                    create.forPath(path, nodeData.getBytes());
+                }
             }
         } catch (KeeperException.NodeExistsException e) {
             if (overwrite) {

--- a/fabric/fabric-zookeeper-commands/src/test/java/io/fabric8/zookeeper/commands/CreateTest.java
+++ b/fabric/fabric-zookeeper-commands/src/test/java/io/fabric8/zookeeper/commands/CreateTest.java
@@ -1,0 +1,55 @@
+package io.fabric8.zookeeper.commands;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.CreateBuilder;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.data.ACL;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class CreateTest extends Assert {
+
+    CreateBuilder createBuilder = mock(CreateBuilder.class);
+
+    CuratorFramework curator = mock(CuratorFramework.class);
+
+    Create createCommand = new Create();
+
+    @Before
+    public void setUp() {
+        createCommand.path = "/foo/bar";
+
+        given(createBuilder.withMode(any(CreateMode.class))).willReturn(createBuilder);
+        given(createBuilder.withACL(anyListOf(ACL.class))).willReturn(createBuilder);
+        given(curator.create()).willReturn(createBuilder);
+    }
+
+    @Test
+    public void shouldCreatePathWithoutData() throws Exception {
+        // When
+        createCommand.doExecute(curator);
+
+        // Then
+        verify(createBuilder).forPath(createCommand.path);
+    }
+
+    @Test
+    public void shouldCreatePathWithData() throws Exception {
+        // Given
+        createCommand.data = "node data";
+
+        // When
+        createCommand.doExecute(curator);
+
+        // Then
+        verify(createBuilder).forPath(createCommand.path, createCommand.data.getBytes());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2266,6 +2266,12 @@
                 <artifactId>easymockclassextension</artifactId>
                 <version>2.4</version>
             </dependency>
+            <!-- Mockito -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>1.9.5</version>
+            </dependency>
             <!-- JSCH -->
             <dependency>
                 <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
Hi,

Currently `zk:create /fabric/foo` command throws `NullPointerException` if executed. This happens when `createCommand.data` is empty (it can be, as passing initial data to the created node is optional) and we try to read bytes from it `nodeData.getBytes()`.

I decided to call `CreateBuilder.create(path)` method if initial data is empty. The latter method sets default Curator's initial data on the node (i.e. client IP address). I considered passing empty byte array there (`CreateBuilder.create(path, new byte[0])`), but decided to stick to the Curator default value to consequently use Curator API in the Karaf commands.

Cheers.
