### PR TITLE
Fixed NPE in recursive zk:create

### DIFF
--- a/fabric/fabric-zookeeper-commands/src/main/java/io/fabric8/zookeeper/commands/Create.java
+++ b/fabric/fabric-zookeeper-commands/src/main/java/io/fabric8/zookeeper/commands/Create.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.BackgroundPathAndBytesable;
+import org.apache.curator.framework.api.CreateBuilder;
 import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
 import org.apache.felix.gogo.commands.Option;
@@ -77,15 +78,15 @@ public class Create extends ZooKeeperCommandSupport {
         }
 
         try {
+            CreateBuilder createBuilder = curator.create();
             if (recursive) {
-                curator.create().creatingParentsIfNeeded().withMode(mode).withACL(acls).forPath(path, nodeData.getBytes());
+                createBuilder.creatingParentsIfNeeded();
+            }
+            BackgroundPathAndBytesable<String> create = createBuilder.withMode(mode).withACL(acls);
+            if (nodeData == null) {
+                create.forPath(path);
             } else {
-                BackgroundPathAndBytesable<String> create = curator.create().withMode(mode).withACL(acls);
-                if (nodeData == null) {
-                    create.forPath(path);
-                } else {
-                    create.forPath(path, nodeData.getBytes());
-                }
+                create.forPath(path, nodeData.getBytes());
             }
         } catch (KeeperException.NodeExistsException e) {
             if (overwrite) {

--- a/fabric/fabric-zookeeper-commands/src/test/java/io/fabric8/zookeeper/commands/CreateTest.java
+++ b/fabric/fabric-zookeeper-commands/src/test/java/io/fabric8/zookeeper/commands/CreateTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.verify;
 
 public class CreateTest extends Assert {
 
+    // Fixtures
+
     CreateBuilder createBuilder = mock(CreateBuilder.class);
 
     CuratorFramework curator = mock(CuratorFramework.class);
@@ -30,6 +32,8 @@ public class CreateTest extends Assert {
         given(createBuilder.withACL(anyListOf(ACL.class))).willReturn(createBuilder);
         given(curator.create()).willReturn(createBuilder);
     }
+
+    // Tests
 
     @Test
     public void shouldCreatePathWithoutData() throws Exception {
@@ -49,6 +53,33 @@ public class CreateTest extends Assert {
         createCommand.doExecute(curator);
 
         // Then
+        verify(createBuilder).forPath(createCommand.path, createCommand.data.getBytes());
+    }
+
+    @Test
+    public void shouldCreateRecursivePathWithoutData() throws Exception {
+        // Given
+        createCommand.recursive = true;
+
+        // When
+        createCommand.doExecute(curator);
+
+        // Then
+        verify(createBuilder).creatingParentsIfNeeded();
+        verify(createBuilder).forPath(createCommand.path);
+    }
+
+    @Test
+    public void shouldCreateRecursivePathWithData() throws Exception {
+        // Given
+        createCommand.recursive = true;
+        createCommand.data = "node data";
+
+        // When
+        createCommand.doExecute(curator);
+
+        // Then
+        verify(createBuilder).creatingParentsIfNeeded();
         verify(createBuilder).forPath(createCommand.path, createCommand.data.getBytes());
     }
 


### PR DESCRIPTION
Fixed another NPE in the `zk:create`. It was similar to the one I fixed in my previous pull request, but this this recursive creation was affected.
