### PR TITLE
ENTESB-1355: ESB/A-MQ should use hawtio-offline out of the box as we don...

### DIFF
--- a/esb/esb-assembly/jboss-fuse-full/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/esb/esb-assembly/jboss-fuse-full/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -34,4 +34,4 @@ featuresRepositories=\
 #
 # Comma separated list of features to install at startup
 #
-featuresBoot=jasypt-encryption,config,management,fabric,fabric-bundle,fabric-maven-proxy,patch,transaction,mq-fabric,camel,camel-cxf,camel-jms,mq-fabric-camel,camel-blueprint,camel-csv,camel-ftp,camel-bindy,camel-jdbc,camel-exec,camel-jasypt,camel-saxon,camel-snmp,camel-ognl,camel-routebox,camel-script,camel-spring-javaconfig,camel-jaxb,camel-jetty,camel-jmx,camel-mail,camel-paxlogging,camel-rmi,war,fabric-redirect,hawtio
+featuresBoot=jasypt-encryption,config,management,fabric,fabric-bundle,fabric-maven-proxy,patch,transaction,mq-fabric,camel,camel-cxf,camel-jms,mq-fabric-camel,camel-blueprint,camel-csv,camel-ftp,camel-bindy,camel-jdbc,camel-exec,camel-jasypt,camel-saxon,camel-snmp,camel-ognl,camel-routebox,camel-script,camel-spring-javaconfig,camel-jaxb,camel-jetty,camel-jmx,camel-mail,camel-paxlogging,camel-rmi,war,fabric-redirect,hawtio-offline

--- a/esb/esb-assembly/jboss-fuse-medium/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/esb/esb-assembly/jboss-fuse-medium/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -34,4 +34,4 @@ featuresRepositories=\
 #
 # Comma separated list of features to install at startup
 #
-featuresBoot=jasypt-encryption,config,management,fabric,fabric-bundle,patch,mq-fabric,camel,camel-cxf,camel-jms,mq-fabric-camel,camel-blueprint,camel-csv,camel-ftp,camel-bindy,camel-jdbc,camel-exec,camel-jasypt,camel-saxon,camel-snmp,camel-ognl,camel-routebox,camel-script,camel-spring-javaconfig,camel-jaxb,camel-jetty,camel-jmx,camel-mail,camel-paxlogging,camel-rmi,war,hawtio
+featuresBoot=jasypt-encryption,config,management,fabric,fabric-bundle,patch,mq-fabric,camel,camel-cxf,camel-jms,mq-fabric-camel,camel-blueprint,camel-csv,camel-ftp,camel-bindy,camel-jdbc,camel-exec,camel-jasypt,camel-saxon,camel-snmp,camel-ognl,camel-routebox,camel-script,camel-spring-javaconfig,camel-jaxb,camel-jetty,camel-jmx,camel-mail,camel-paxlogging,camel-rmi,war,hawtio-offline

--- a/mq/jboss-a-mq/src/main/resources/etc/org.apache.karaf.features.cfg
+++ b/mq/jboss-a-mq/src/main/resources/etc/org.apache.karaf.features.cfg
@@ -31,4 +31,4 @@ featuresRepositories=\
 #
 # Comma separated list of features to install at startup
 #
-featuresBoot=config,fabric-bundle,fabric,patch,mq-fabric,war,hawtio
+featuresBoot=config,fabric-bundle,fabric,patch,mq-fabric,war,hawtio-offline


### PR DESCRIPTION
...t want the maven indexer to access internet during startup. Also avoids exceptions in the log when creating fabric which reprovision the container, while the indexer is still running.
