### PR TITLE
Remove @author in source code as per issue 1040

### DIFF
--- a/fab/fab-core/src/main/java/io/fabric8/fab/MavenRepositorySystemSession.java
+++ b/fab/fab-core/src/main/java/io/fabric8/fab/MavenRepositorySystemSession.java
@@ -44,7 +44,6 @@ import io.fabric8.maven.util.MavenUtils;
  * Maven's dependency resolution into their own applications. <strong>Warning:</strong> This class is not intended for
  * usage by Maven plugins, those should always acquire the current repository system session via parameter injection.
  *
- * @author Benjamin Bentmann
  */
 public class MavenRepositorySystemSession
     extends DefaultRepositorySystemSession

--- a/fab/fab-core/src/main/java/io/fabric8/fab/ModuleRegistry.java
+++ b/fab/fab-core/src/main/java/io/fabric8/fab/ModuleRegistry.java
@@ -29,7 +29,6 @@ import static java.util.Collections.sort;
  * and extension relationships.
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class ModuleRegistry {
 

--- a/fab/fab-core/src/main/java/io/fabric8/fab/ReplaceConflictingVersionResolver.java
+++ b/fab/fab-core/src/main/java/io/fabric8/fab/ReplaceConflictingVersionResolver.java
@@ -44,7 +44,6 @@ import java.util.Map;
  * {@link TransformationContextKeys#SORTED_CONFLICT_IDS} for existing information about conflict ids. In absence of this
  * information, it will automatically invoke the {@link ConflictIdSorter} to calculate it.
  *
- * @author Benjamin Bentmann
  * @see NearestVersionConflictResolver
  */
 public class ReplaceConflictingVersionResolver

--- a/fab/fab-core/src/main/java/io/fabric8/fab/VersionedDependencyId.java
+++ b/fab/fab-core/src/main/java/io/fabric8/fab/VersionedDependencyId.java
@@ -25,7 +25,6 @@ import static io.fabric8.common.util.Strings.nullIfEmpty;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class VersionedDependencyId extends DependencyId {
 

--- a/fab/fab-core/src/test/java/io/fabric8/fab/ModuleRegistryTest.java
+++ b/fab/fab-core/src/test/java/io/fabric8/fab/ModuleRegistryTest.java
@@ -30,7 +30,6 @@ import java.util.Properties;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class ModuleRegistryTest extends TestCase {
 

--- a/fab/fab-osgi/src/main/java/io/fabric8/fab/osgi/internal/BndUtils.java
+++ b/fab/fab-osgi/src/main/java/io/fabric8/fab/osgi/internal/BndUtils.java
@@ -65,7 +65,6 @@ import static io.fabric8.common.util.Strings.notEmpty;
 /**
  * Wrapper over PeterK's bnd lib.
  *
- * @author Alin Dreghiciu
  * @since 0.1.0, January 14, 2008
  */
 public class BndUtils

--- a/fab/fab-osgi/src/main/java/io/fabric8/fab/osgi/internal/OsgiModuleRegistry.java
+++ b/fab/fab-osgi/src/main/java/io/fabric8/fab/osgi/internal/OsgiModuleRegistry.java
@@ -34,7 +34,6 @@ import static io.fabric8.common.util.Strings.*;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class OsgiModuleRegistry extends ModuleRegistry {
 

--- a/fab/fab-osgi/src/main/java/io/fabric8/fab/osgi/internal/OverwriteMode.java
+++ b/fab/fab-osgi/src/main/java/io/fabric8/fab/osgi/internal/OverwriteMode.java
@@ -20,7 +20,6 @@ package io.fabric8.fab.osgi.internal;
 /**
  * Strategy to use regarding manifest rewrite, for a jar that is already a bundle (has osgi manifest attributes).
  *
- * @author Alin Dreghiciu (adreghiciu@gmail.com)
  * @since 1.1.1, September 17, 2009
  */
 public enum OverwriteMode

--- a/fabric/bisect-fabric.sh
+++ b/fabric/bisect-fabric.sh
@@ -6,7 +6,6 @@
 # git bisect start [badrev] [goodrev]
 # git bisect run ./bisect-fabric.sh
 #
-# @author thomas.diesler@jboss.com
 # @since 15-Sep-2013
 
 mvn -ff clean install | tee mvn.out

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/download/FutureListener.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/download/FutureListener.java
@@ -22,7 +22,6 @@ import java.util.EventListener;
  * Something interested in being notified when the completion
  * of an asynchronous download operation : {@link Future}.
  *
- * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
  */
 public interface FutureListener<T extends Future> extends EventListener {
 

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/DictionaryPropertyResolver.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/DictionaryPropertyResolver.java
@@ -21,7 +21,6 @@ import java.util.Dictionary;
 /**
  * Resolves properties from a Dictionary.
  *
- * @author Alin Dreghiciu
  * @since 0.5.0, January 16, 2008
  */
 public class DictionaryPropertyResolver

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/DownloadableArtifact.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/DownloadableArtifact.java
@@ -26,7 +26,6 @@ import io.fabric8.utils.URLUtils;
 /**
  * An artifact that can be downloaded.
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 public class DownloadableArtifact {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/FallbackPropertyResolver.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/FallbackPropertyResolver.java
@@ -19,7 +19,6 @@ package io.fabric8.agent.mvn;
 /**
  * Resolves properties by first looking at itself and then to a falback resolver.
  *
- * @author Alin Dreghiciu
  * @since 0.5.0, January 16, 2008
  */
 public abstract class FallbackPropertyResolver

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/IntegerVersionSegment.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/IntegerVersionSegment.java
@@ -21,7 +21,6 @@ import io.fabric8.utils.NullArgumentException;
 /**
  * A version segment backed up by a String.
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 class IntegerVersionSegment

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenConfiguration.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenConfiguration.java
@@ -23,7 +23,6 @@ import java.util.List;
 /**
  * Handler configuration.
  *
- * @author Alin Dreghiciu
  * @since August 11, 2007
  */
 public interface MavenConfiguration {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenConfigurationImpl.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenConfigurationImpl.java
@@ -32,7 +32,6 @@ import io.fabric8.utils.NullArgumentException;
 /**
  * Service Configuration implementation.
  *
- * @author Alin Dreghiciu
  * @see MavenConfiguration
  * @since August 11, 2007
  */

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenConstants.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenConstants.java
@@ -19,7 +19,6 @@ package io.fabric8.agent.mvn;
 /**
  * An enumeration of constants related to maven handler.
  *
- * @author Alin Dreghiciu
  * @since August 26, 2007
  */
 public interface MavenConstants {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenRepositoryURL.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenRepositoryURL.java
@@ -25,7 +25,6 @@ import io.fabric8.utils.NullArgumentException;
 /**
  * An URL of Maven repository that knows if it contains SNAPSHOT versions and/or releases.
  *
- * @author Alin Dreghiciu
  * @since 0.2.1, February 07, 2008
  */
 public class MavenRepositoryURL {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenSettings.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenSettings.java
@@ -21,7 +21,6 @@ import java.util.Map;
 /**
  * Abstracts access to maven settings.xml.
  *
- * @author Alin Dreghiciu
  * @since August 10, 2007
  */
 public interface MavenSettings {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenSettingsImpl.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/MavenSettingsImpl.java
@@ -30,7 +30,6 @@ import org.w3c.dom.Document;
 /**
  * Default implementation of Settings.
  *
- * @author Alin Dreghiciu
  * @see MavenSettings
  * @since August 10, 2007
  */

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/NullVersionSegment.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/NullVersionSegment.java
@@ -19,7 +19,6 @@ package io.fabric8.agent.mvn;
 /**
  * A null version. Smaller then anything else.
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 class NullVersionSegment

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/Parser.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/Parser.java
@@ -21,7 +21,6 @@ import java.net.MalformedURLException;
 /**
  * Parser for mvn: protocol.<br/>
  *
- * @author Alin Dreghiciu
  * @since August 10, 2007
  */
 public class Parser {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/PropertiesPropertyResolver.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/PropertiesPropertyResolver.java
@@ -21,7 +21,6 @@ import java.util.Properties;
 /**
  * Resolves properties from a Properties.
  *
- * @author Alin Dreghiciu
  * @since 0.5.0, January 16, 2008
  */
 public class PropertiesPropertyResolver

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/PropertyResolver.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/PropertyResolver.java
@@ -19,7 +19,6 @@ package io.fabric8.agent.mvn;
 /**
  * Properties resolver.
  *
- * @author Alin Dreghiciu
  * @since 0.5.0, January 16, 2008
  */
 public interface PropertyResolver {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/PropertyStore.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/PropertyStore.java
@@ -22,7 +22,6 @@ import java.util.Map;
 /**
  * A simple generics based property store.
  *
- * @author Alin Dreghiciu
  * @since August 26, 2007
  */
 public class PropertyStore {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/SnapshotVersionSegment.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/SnapshotVersionSegment.java
@@ -20,7 +20,6 @@ package io.fabric8.agent.mvn;
  * A SNAPSHOT version segment. Acts as a StringVersionSegment beside that in comparations is considerided as the lowest
  * segment.
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 class SnapshotVersionSegment

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/StringVersionSegment.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/StringVersionSegment.java
@@ -21,7 +21,6 @@ import io.fabric8.utils.NullArgumentException;
 /**
  * A version segment backed up by a String.
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 class StringVersionSegment

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/Version.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/Version.java
@@ -21,7 +21,6 @@ import io.fabric8.utils.NullArgumentException;
 /**
  * Represents an artifact version.
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 public class Version

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/VersionRange.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/VersionRange.java
@@ -24,7 +24,6 @@ import io.fabric8.utils.NullArgumentException;
  * The range consist of two versions separated by "," (comma) that starts and ends with "[" for inclusive match or "("
  * for exclusive match and ends with "]" for inclusive match or ")" for exclusive match
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 public class VersionRange {

--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/VersionSegment.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/mvn/VersionSegment.java
@@ -21,7 +21,6 @@ package io.fabric8.agent.mvn;
  * or "-" (dash).
  * A segment can be of different forms such as integers or strings.
  *
- * @author Alin Dreghiciu
  * @since 0.2.0, January 30, 2008
  */
 interface VersionSegment

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/DataStore.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/DataStore.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Stan Lewis
  */
 public interface DataStore {
 

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/NotNullException.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/NotNullException.java
@@ -22,7 +22,6 @@ package io.fabric8.api;
 /**
  * NotNullException
  *
- * @author thomas.diesler@jboss.com
  * @since 27-Sep-2013
  */
 public final class NotNullException {

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/TargetContainer.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/TargetContainer.java
@@ -25,7 +25,6 @@ package io.fabric8.api;
 /**
  * The enumeration of supported target containers
  *
- * @author thomas.diesler@jboss.com
  * @since 22-Nov-2013
  */
 public enum TargetContainer {

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/scr/AbstractComponent.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/scr/AbstractComponent.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 /**
  * An abstract base class for validatable components.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Sep-2013
  */
 @ThreadSafe

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/scr/InvalidComponentException.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/scr/InvalidComponentException.java
@@ -19,7 +19,6 @@ package io.fabric8.api.scr;
 /**
  * A runtime exception thrown by invalid components.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Sep-2013
  */
 public class InvalidComponentException extends RuntimeException {

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/scr/Validatable.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/scr/Validatable.java
@@ -19,7 +19,6 @@ package io.fabric8.api.scr;
 /**
  * An interface implemented by validatable components.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Sep-2013
  */
 public interface Validatable {

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/scr/ValidatingReference.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/scr/ValidatingReference.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 /**
  * A reference that validates its content on {@link #get()}
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Sep-2013
  */
 @ThreadSafe

--- a/fabric/fabric-api/src/main/java/io/fabric8/api/scr/ValidationSupport.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/scr/ValidationSupport.java
@@ -22,7 +22,6 @@ import io.fabric8.api.jcip.ThreadSafe;
 /**
  * Provides validation support.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Sep-2013
  */
 @ThreadSafe

--- a/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/support/AbstractCommandComponent.java
+++ b/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/support/AbstractCommandComponent.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 /**
  * An abstract base class for validatable command components.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 05-Feb-2014
  */
 @ThreadSafe

--- a/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/support/AbstractCompleterComponent.java
+++ b/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/support/AbstractCompleterComponent.java
@@ -21,7 +21,6 @@ import io.fabric8.api.scr.AbstractComponent;
 /**
  * An abstract base class for command completers.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 12-Mar-2014
  */
 public abstract class AbstractCompleterComponent extends AbstractComponent implements ParameterCompleter {

--- a/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/support/ParameterCompleter.java
+++ b/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/support/ParameterCompleter.java
@@ -22,7 +22,6 @@ import org.apache.karaf.shell.console.Completer;
 /**
  * A completer that names its default parameter
  *
- * @author Thomas.Diesler@jboss.com
  * @since 12-Mar-2014
  */
 public interface ParameterCompleter extends Completer {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/CustomerDetails.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/CustomerDetails.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
  * <li><b>Vendor ID</b> of type <code>long</code> (1)</li>
  * <li><b>Country</b> of type {@link java.lang.String} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.CustomerDetailsClass
  **/
 public class CustomerDetails extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/CustomerDetailsClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/CustomerDetailsClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The Customer Details complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.CustomerDetails
  **/
 public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType 
@@ -80,7 +79,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Amount atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class AmountClass extends biz.c24.io.api.data.DoubleDataType 
     {
@@ -138,7 +136,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Card Number atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CardNumberClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -196,7 +193,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Commission atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CommissionClass extends biz.c24.io.api.data.DoubleDataType 
     {
@@ -254,7 +250,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Country atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CountryClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -311,7 +306,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Currency atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CurrencyClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -368,7 +362,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Expiry Date atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class ExpiryDateClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -426,7 +419,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Name atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class NameClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -483,7 +475,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Transaction Date atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class TransactionDateClass extends biz.c24.io.api.data.GenericDateDataType 
     {
@@ -541,7 +532,6 @@ public class CustomerDetailsClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Vendor ID atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class VendorIDClass extends biz.c24.io.api.data.LongDataType 
     {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/Header.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/Header.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
  * <li><b>Vendor ID</b> of type {@link java.lang.String} (1)</li>
  * <li><b>Country</b> of type {@link java.lang.String} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.HeaderClass
  **/
 public class Header extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/HeaderClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/HeaderClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The Header complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.Header
  **/
 public class HeaderClass extends biz.c24.io.api.data.ComplexDataType 
@@ -79,7 +78,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Amount atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class AmountClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -136,7 +134,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Card Number atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CardNumberClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -194,7 +191,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Commission atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CommissionClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -251,7 +247,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Country atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CountryClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -308,7 +303,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Currency atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class CurrencyClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -365,7 +359,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Expiry Date atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class ExpiryDateClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -423,7 +416,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Name atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class NameClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -480,7 +472,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Transaction Date atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class TransactionDateClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -538,7 +529,6 @@ public class HeaderClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Vendor ID atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class VendorIDClass extends biz.c24.io.api.data.GenericStringDataType 
     {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/RowCheckRuleRule.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/RowCheckRuleRule.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The rowCheckRule validation rule.
  * 
- * @author C24 Integration Objects;
  **/
 public class RowCheckRuleRule extends biz.c24.io.api.data.XPathRule 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/RowCount.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/RowCount.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
  * <li><b>Prefix</b> of type {@link java.lang.String} (1)</li>
  * <li><b>Value</b> of type <code>long</code> (0..1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.RowCountClass
  **/
 public class RowCount extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/RowCountClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/RowCountClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The Row Count complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.RowCount
  **/
 public class RowCountClass extends biz.c24.io.api.data.ComplexDataType 
@@ -65,7 +64,6 @@ public class RowCountClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Prefix atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class PrefixClass extends biz.c24.io.api.data.GenericStringDataType 
     {
@@ -123,7 +121,6 @@ public class RowCountClass extends biz.c24.io.api.data.ComplexDataType
     /**
      * The Value atomic simple data type.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class ValueClass extends biz.c24.io.api.data.LongDataType 
     {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/Transactions.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/Transactions.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
  * <li><b>Customer Details</b> of type {@link biz.c24.io.gettingstarted.transaction.CustomerDetails} (1..*)</li>
  * <li><b>Row Count</b> of type {@link biz.c24.io.gettingstarted.transaction.RowCount} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.TransactionsClass
  **/
 public class Transactions extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The Transactions complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.Transactions
  **/
 public class TransactionsClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsDataModel.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsDataModel.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The Transactions data model.
  * 
- * @author C24 Integration Objects;
  **/
 public class TransactionsDataModel extends biz.c24.io.api.data.DataModel 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsDocumentRoot.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsDocumentRoot.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
  * <ul>
  * <li><b>Transactions</b> of type {@link biz.c24.io.gettingstarted.transaction.Transactions} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.gettingstarted.transaction.TransactionsDocumentRootElement.TransactionsDocumentRootClass
  **/
 public class TransactionsDocumentRoot extends biz.c24.io.api.data.DocumentRoot 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsDocumentRootElement.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsDocumentRootElement.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The Document Root element.
  * 
- * @author C24 Integration Objects;
  **/
 public class TransactionsDocumentRootElement extends biz.c24.io.api.data.Element 
 {
@@ -89,7 +88,6 @@ public class TransactionsDocumentRootElement extends biz.c24.io.api.data.Element
     /**
      * The Document Root complex data type.
      * 
-     * @author C24 Integration Objects;
      * @see biz.c24.io.gettingstarted.transaction.TransactionsDocumentRoot
      **/
     public static class TransactionsDocumentRootClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsElement.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/TransactionsElement.java
@@ -4,7 +4,6 @@ package biz.c24.io.gettingstarted.transaction;
 /**
  * The Transactions element.
  * 
- * @author C24 Integration Objects;
  **/
 public class TransactionsElement extends biz.c24.io.api.data.Element 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/transactions/StatGenTransform.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/gettingstarted/transaction/transactions/StatGenTransform.java
@@ -3,7 +3,6 @@ package biz.c24.io.gettingstarted.transaction.transactions;
 
 /**
  * 
- * @author C24 Integration Objects;
  **/
 public class StatGenTransform extends biz.c24.io.api.transform.Transform 
 {
@@ -136,7 +135,6 @@ public class StatGenTransform extends biz.c24.io.api.transform.Transform
 
     /**
      * 
-     * @author C24 Integration Objects;
      **/
     public class JustScroogeFilter extends biz.c24.io.api.transform.Filter 
     {
@@ -155,7 +153,6 @@ public class StatGenTransform extends biz.c24.io.api.transform.Transform
 
     /**
      * 
-     * @author C24 Integration Objects;
      **/
     public class RecordToStmtLineTransform extends biz.c24.io.api.transform.Transform 
     {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/AddressType2CodeClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/AddressType2CodeClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The AddressType2Code atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class AddressType2CodeClass extends biz.c24.io.api.data.GenericStringDataType 
 {
@@ -57,7 +56,6 @@ public class AddressType2CodeClass extends biz.c24.io.api.data.GenericStringData
     /**
      * The AddressType2Code enumeration.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class AddressType2Code1Enum extends biz.c24.io.api.data.DefaultEnumeration 
     {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CountryCodeClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CountryCodeClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The CountryCode atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class CountryCodeClass extends biz.c24.io.api.data.GenericStringDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyAndAmount.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyAndAmount.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
  * <ul>
  * <li><b>Ccy</b> of type {@link java.lang.String} (required)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.CurrencyAndAmountClass
  **/
 public class CurrencyAndAmount extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyAndAmountClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyAndAmountClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The CurrencyAndAmount complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.CurrencyAndAmount
  **/
 public class CurrencyAndAmountClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyAndAmount_SimpleTypeClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyAndAmount_SimpleTypeClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The CurrencyAndAmount_SimpleType atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class CurrencyAndAmount_SimpleTypeClass extends biz.c24.io.api.data.FloatDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyCodeClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/CurrencyCodeClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The CurrencyCode atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class CurrencyCodeClass extends biz.c24.io.api.data.GenericStringDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/DebitCreditIndicatorClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/DebitCreditIndicatorClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The DebitCreditIndicator atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class DebitCreditIndicatorClass extends biz.c24.io.api.data.GenericStringDataType 
 {
@@ -57,7 +56,6 @@ public class DebitCreditIndicatorClass extends biz.c24.io.api.data.GenericString
     /**
      * The DebitCreditIndicator enumeration.
      * 
-     * @author C24 Integration Objects;
      **/
     public static class DebitCreditIndicator1Enum extends biz.c24.io.api.data.DefaultEnumeration 
     {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Header.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Header.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
  * <li><b>Account</b> of type {@link java.lang.String} (1)</li>
  * <li><b>StartBalance</b> of type {@link biz.c24.io.training.statements.CurrencyAndAmount} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.HeaderClass
  **/
 public class Header extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/HeaderClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/HeaderClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Header complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.Header
  **/
 public class HeaderClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/IBANIdentifierClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/IBANIdentifierClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The IBANIdentifier atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class IBANIdentifierClass extends biz.c24.io.api.data.GenericStringDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/ISODateClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/ISODateClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The ISODate atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class ISODateClass extends biz.c24.io.api.data.ISO8601DateDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max140TextClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max140TextClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Max140Text atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class Max140TextClass extends biz.c24.io.api.data.GenericStringDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max16TextClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max16TextClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Max16Text atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class Max16TextClass extends biz.c24.io.api.data.GenericStringDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max35TextClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max35TextClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Max35Text atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class Max35TextClass extends biz.c24.io.api.data.GenericStringDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max5IntegerClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max5IntegerClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Max5Integer atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class Max5IntegerClass extends biz.c24.io.api.data.IntegerDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max70TextClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Max70TextClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Max70Text atomic simple data type.
  * 
- * @author C24 Integration Objects;
  **/
 public class Max70TextClass extends biz.c24.io.api.data.GenericStringDataType 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/PostalAddress1.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/PostalAddress1.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
  * <li><b>CtrySubDvsn</b> of type {@link java.lang.String} (0..1)</li>
  * <li><b>Ctry</b> of type {@link java.lang.String} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.PostalAddress1Class
  **/
 public class PostalAddress1 extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/PostalAddress1Class.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/PostalAddress1Class.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The PostalAddress1 complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.PostalAddress1
  **/
 public class PostalAddress1Class extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Statement.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Statement.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
  * <li><b>StmtLine</b> of type {@link biz.c24.io.training.statements.StatementLine} (0..*)</li>
  * <li><b>Tlr</b> of type {@link biz.c24.io.training.statements.Trailer} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.StatementClass
  **/
 public class Statement extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Statement complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.Statement
  **/
 public class StatementClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementElement.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementElement.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Statement element.
  * 
- * @author C24 Integration Objects;
  **/
 public class StatementElement extends biz.c24.io.api.data.Element 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementFile.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementFile.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
  * <ul>
  * <li><b>Statement</b> of type {@link biz.c24.io.training.statements.Statement} (0..*)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.StatementFileClass
  **/
 public class StatementFile extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementFileClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementFileClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The StatementFile complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.StatementFile
  **/
 public class StatementFileClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementFileElement.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementFileElement.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The StatementFile element.
  * 
- * @author C24 Integration Objects;
  **/
 public class StatementFileElement extends biz.c24.io.api.data.Element 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementLine.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementLine.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
  * <li><b>TxAmount</b> of type {@link biz.c24.io.training.statements.CurrencyAndAmount} (1)</li>
  * <li><b>PostingNarrative</b> of type {@link java.lang.String} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.StatementLineClass
  **/
 public class StatementLine extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementLineClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementLineClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The StatementLine complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.StatementLine
  **/
 public class StatementLineClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementsDataModel.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementsDataModel.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Statements data model.
  * 
- * @author C24 Integration Objects;
  **/
 public class StatementsDataModel extends biz.c24.io.api.data.DataModel 
 {

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementsDocumentRoot.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementsDocumentRoot.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
  * <li><b>StatementFile</b> of type {@link biz.c24.io.training.statements.StatementFile} (1)</li>
  * <li><b>Statement</b> of type {@link biz.c24.io.training.statements.Statement} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.StatementsDocumentRootElement.StatementsDocumentRootClass
  **/
 public class StatementsDocumentRoot extends biz.c24.io.api.data.DocumentRoot 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementsDocumentRootElement.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/StatementsDocumentRootElement.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Document Root element.
  * 
- * @author C24 Integration Objects;
  **/
 public class StatementsDocumentRootElement extends biz.c24.io.api.data.Element 
 {
@@ -89,7 +88,6 @@ public class StatementsDocumentRootElement extends biz.c24.io.api.data.Element
     /**
      * The Document Root complex data type.
      * 
-     * @author C24 Integration Objects;
      * @see biz.c24.io.training.statements.StatementsDocumentRoot
      **/
     public static class StatementsDocumentRootClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Trailer.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/Trailer.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
  * <ul>
  * <li><b>EndBalance</b> of type {@link biz.c24.io.training.statements.CurrencyAndAmount} (1)</li>
  * </ul>
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.TrailerClass
  **/
 public class Trailer extends biz.c24.io.api.data.ComplexDataObject 

--- a/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/TrailerClass.java
+++ b/fabric/fabric-camel-c24io/src/test/java/biz/c24/io/training/statements/TrailerClass.java
@@ -4,7 +4,6 @@ package biz.c24.io.training.statements;
 /**
  * The Trailer complex data type.
  * 
- * @author C24 Integration Objects;
  * @see biz.c24.io.training.statements.Trailer
  **/
 public class TrailerClass extends biz.c24.io.api.data.ComplexDataType 

--- a/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/JolokiaFabricConnector.java
+++ b/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/JolokiaFabricConnector.java
@@ -5,7 +5,6 @@ import io.fabric8.jolokia.facade.mbeans.FabricMBean;
 import org.jolokia.client.J4pClient;
 
 /**
- * @author Stan Lewis
  */
 public class JolokiaFabricConnector {
 

--- a/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/facades/ContainerFacade.java
+++ b/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/facades/ContainerFacade.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * @author Stan Lewis
  */
 public class ContainerFacade implements Container, HasId {
 

--- a/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/facades/ProfileFacade.java
+++ b/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/facades/ProfileFacade.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Stan Lewis
  */
 public class ProfileFacade implements Profile, HasId {
 

--- a/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/facades/VersionFacade.java
+++ b/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/facades/VersionFacade.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Stan Lewis
  */
 public class VersionFacade implements Version, HasId {
 

--- a/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/utils/FieldsToIgnoreForDeserializationMixin.java
+++ b/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/utils/FieldsToIgnoreForDeserializationMixin.java
@@ -6,7 +6,6 @@ import io.fabric8.api.Container;
 import java.net.URI;
 
 /**
- * @author Stan Lewis
  */
 public abstract class FieldsToIgnoreForDeserializationMixin {
 

--- a/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/utils/FieldsToIgnoreForSerializationMixin.java
+++ b/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/utils/FieldsToIgnoreForSerializationMixin.java
@@ -4,7 +4,6 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import io.fabric8.api.CreationStateListener;
 
 /**
- * @author Stan Lewis
  */
 public abstract class FieldsToIgnoreForSerializationMixin {
 

--- a/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/utils/Helpers.java
+++ b/fabric/fabric-client/src/main/java/io/fabric8/jolokia/facade/utils/Helpers.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Stan Lewis
  */
 public class Helpers {
 

--- a/fabric/fabric-client/src/test/java/io/fabric8/jolokia/facade/FabricServiceFacadeTest.java
+++ b/fabric/fabric-client/src/test/java/io/fabric8/jolokia/facade/FabricServiceFacadeTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import java.net.URI;
 
 /**
- * @author Stan Lewis
  */
 @Ignore("[FABRIC-783] Fix jolokia FabricServiceFacadeTest")
 public class FabricServiceFacadeTest {

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/BeanUtils.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/BeanUtils.java
@@ -7,7 +7,6 @@ import java.beans.PropertyDescriptor;
 import java.util.*;
 
 /**
- * @author Stan Lewis
  */
 public class BeanUtils {
 

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterBootstrapManager.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterBootstrapManager.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * @author Stan Lewis
  */
 @ThreadSafe
 @Component(label = "Fabric8 ZooKeeper Cluster Bootstrap Manager JMX MBean", metatype = false)

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterBootstrapManagerMBean.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterBootstrapManagerMBean.java
@@ -3,7 +3,6 @@ package io.fabric8.api.jmx;
 import java.util.Map;
 
 /**
- * @author Stan Lewis
  */
 public interface ClusterBootstrapManagerMBean {
 

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterServiceManager.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterServiceManager.java
@@ -18,7 +18,6 @@ import io.fabric8.api.jcip.ThreadSafe;
 import io.fabric8.api.scr.AbstractComponent;
 import io.fabric8.api.scr.ValidatingReference;
 /**
- * @author Stan Lewis
  */
 @ThreadSafe
 @Component(label = "Fabric8 ZooKeeper Cluster Manager JMX MBean", metatype = false)

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterServiceManagerMBean.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ClusterServiceManagerMBean.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * @author Stan Lewis
  */
 public interface ClusterServiceManagerMBean extends ZooKeeperClusterService {
 

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/JMXUtils.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/JMXUtils.java
@@ -4,7 +4,6 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 /**
- * @author Stan Lewis
  */
 public class JMXUtils {
 

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ServiceStatusDTO.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/ServiceStatusDTO.java
@@ -1,7 +1,6 @@
 package io.fabric8.api.jmx;
 
 /**
- * @author Stan Lewis
  */
 public class ServiceStatusDTO {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/AsyncCallback.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/AsyncCallback.java
@@ -20,7 +20,6 @@ package io.fabric8.dosgi.api;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface AsyncCallback<T> {
     void onSuccess(T result);

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/AsyncCallbackFuture.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/AsyncCallbackFuture.java
@@ -23,7 +23,6 @@ import java.util.concurrent.FutureTask;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class AsyncCallbackFuture<T> extends FutureTask<T> implements AsyncCallback<T> {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/Dispatched.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/Dispatched.java
@@ -24,7 +24,6 @@ import org.fusesource.hawtdispatch.DispatchQueue;
  * of a dispatch queue.
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface Dispatched {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/ObjectSerializationStrategy.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/ObjectSerializationStrategy.java
@@ -27,7 +27,6 @@ import java.io.ObjectOutputStream;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class ObjectSerializationStrategy implements SerializationStrategy {
     public static final ObjectSerializationStrategy INSTANCE = new ObjectSerializationStrategy();

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/ProtobufSerializationStrategy.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/ProtobufSerializationStrategy.java
@@ -29,7 +29,6 @@ import java.lang.reflect.InvocationTargetException;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class ProtobufSerializationStrategy implements SerializationStrategy {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/SerializationStrategy.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/api/SerializationStrategy.java
@@ -23,7 +23,6 @@ import org.fusesource.hawtbuf.DataByteArrayOutputStream;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface SerializationStrategy {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/io/ProtocolCodec.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/io/ProtocolCodec.java
@@ -25,7 +25,6 @@ import java.nio.channels.WritableByteChannel;
 /**
  * Interface to encode and decode commands in and out of a a non blocking channel.
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface ProtocolCodec {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/io/Transport.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/io/Transport.java
@@ -22,7 +22,6 @@ import org.fusesource.hawtdispatch.DispatchQueue;
 /**
  * Represents an abstract connection.  It can be a client side or server side connection.
  * 
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface Transport extends Service, Dispatched {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/io/TransportAcceptListener.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/io/TransportAcceptListener.java
@@ -22,7 +22,6 @@ import io.fabric8.dosgi.tcp.TcpTransport;
 /**
  * Implemented by object that need to get injected by
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface TransportAcceptListener {
     

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/AsyncInvocationStrategy.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/AsyncInvocationStrategy.java
@@ -36,7 +36,6 @@ import org.fusesource.hawtdispatch.DispatchQueue;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class AsyncInvocationStrategy implements InvocationStrategy {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/BlockingInvocationStrategy.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/BlockingInvocationStrategy.java
@@ -33,7 +33,6 @@ import org.fusesource.hawtdispatch.Dispatch;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class BlockingInvocationStrategy implements InvocationStrategy {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/InvocationStrategy.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/InvocationStrategy.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Method;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface InvocationStrategy {
 

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/ResponseFuture.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/ResponseFuture.java
@@ -24,7 +24,6 @@ import org.fusesource.hawtbuf.DataByteArrayInputStream;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface ResponseFuture {
     void set(DataByteArrayInputStream responseStream) throws Exception;

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/TcpTransportFactory.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/TcpTransportFactory.java
@@ -32,8 +32,6 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
- * @author David Martin Clavo david(dot)martin(dot)clavo(at)gmail.com (logging improvement modifications)
  */
 public class TcpTransportFactory {
     private static final Logger LOG = LoggerFactory.getLogger(TcpTransportFactory.class);

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/TcpTransportServer.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/tcp/TcpTransportServer.java
@@ -39,7 +39,6 @@ import org.fusesource.hawtdispatch.DispatchSource;
 /**
  * A TCP based transport server
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 
 public class TcpTransportServer implements TransportServer {

--- a/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/util/StringSupport.java
+++ b/fabric/fabric-dosgi/src/main/java/io/fabric8/dosgi/util/StringSupport.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 /**
  * Helper class to hold common text/string manipulation methods.
  *  
- * @author chirino
  */
 public class StringSupport {
 

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/GroupListener.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/GroupListener.java
@@ -22,7 +22,6 @@ package io.fabric8.groups;
  *   to a cluster group.
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface GroupListener<T extends NodeState> {
 

--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/NodeState.java
@@ -22,7 +22,6 @@ import io.fabric8.groups.internal.ZooKeeperGroup;
 import java.util.UUID;
 
 /**
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class NodeState {
 

--- a/fabric/fabric-utils/src/main/java/io/fabric8/utils/AllCertificatesTrustManager.java
+++ b/fabric/fabric-utils/src/main/java/io/fabric8/utils/AllCertificatesTrustManager.java
@@ -24,8 +24,6 @@ import javax.net.ssl.X509TrustManager;
  * a mechanism through which https connections can be established with the same notion of trust as a http connection
  * (i.e. none).
  *
- * @author Niclas Hedhman
- * @author Alin Dreghiciu
  * @since 0.5.0, January 16, 2008
  */
 public final class AllCertificatesTrustManager

--- a/fabric/fabric-utils/src/main/java/io/fabric8/utils/AuthenticationUtils.java
+++ b/fabric/fabric-utils/src/main/java/io/fabric8/utils/AuthenticationUtils.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import org.apache.karaf.jaas.boot.principal.UserPrincipal;
 
 /**
- * @author Stan Lewis
  */
 public class AuthenticationUtils {
 

--- a/fabric/fabric-utils/src/main/java/io/fabric8/utils/Base64Encoder.java
+++ b/fabric/fabric-utils/src/main/java/io/fabric8/utils/Base64Encoder.java
@@ -21,8 +21,6 @@ import java.nio.charset.Charset;
 /**
  * Bease64 encoding utilities.
  *
- * @author Niclas Hedhman
- * @author Alin Dreghiciu
  * @since 0.5.0, January 16, 2008
  */
 public class Base64Encoder {

--- a/fabric/fabric-utils/src/main/java/io/fabric8/utils/Constants.java
+++ b/fabric/fabric-utils/src/main/java/io/fabric8/utils/Constants.java
@@ -1,7 +1,6 @@
 package io.fabric8.utils;
 
 /**
- * @author Stan Lewis
  */
 public interface Constants {
 

--- a/fabric/fabric-utils/src/main/java/io/fabric8/utils/NullArgumentException.java
+++ b/fabric/fabric-utils/src/main/java/io/fabric8/utils/NullArgumentException.java
@@ -36,7 +36,6 @@ import java.util.Properties;
  *     }
  * </pre></code>
  *
- * @author <a href="http://www.ops4j.org">Open Particpation Software for Java</a>
  * @version $Id: NullArgumentException.java 10276 2008-01-25 09:59:47Z adreghiciu@gmail.com $
  */
 public class NullArgumentException extends IllegalArgumentException {

--- a/fabric/fabric-utils/src/main/java/io/fabric8/utils/URLUtils.java
+++ b/fabric/fabric-utils/src/main/java/io/fabric8/utils/URLUtils.java
@@ -30,8 +30,6 @@ import javax.net.ssl.TrustManager;
 /**
  * Url related utility methods.
  *
- * @author Niclas Heldman
- * @author Alin Dreghiciu
  * @since 0.5.0, January 16, 2008
  */
 public class URLUtils {

--- a/fabric/fabric-utils/src/main/java/io/fabric8/utils/XmlUtils.java
+++ b/fabric/fabric-utils/src/main/java/io/fabric8/utils/XmlUtils.java
@@ -39,8 +39,6 @@ import org.xml.sax.SAXException;
  * XML related utilities.
  * TODO merge this clas with ElementHelper
  *
- * @author Alin Dreghiciu
- * @author Niclas Heldman
  */
 public class XmlUtils {
 

--- a/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/curator/CuratorFrameworkLocator.java
+++ b/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/curator/CuratorFrameworkLocator.java
@@ -28,7 +28,6 @@ import org.apache.curator.framework.CuratorFramework;
 /**
  * Locate the {@link CuratorFramework}
  *
- * @author thomas.diesler@jboss.com
  * @since 10-Dec-2013
  */
 public final class CuratorFrameworkLocator  {

--- a/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/internal/SimplePathTemplate.java
+++ b/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/internal/SimplePathTemplate.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
 /**
  * Basic template for paths.
  *
- * @author ldywicki
  */
 public class SimplePathTemplate {
 

--- a/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/utils/InterpolationHelper.java
+++ b/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/utils/InterpolationHelper.java
@@ -27,7 +27,6 @@ import org.osgi.framework.BundleContext;
  * managing the maintain of comments, etc.
  * </p>
  *
- * @author gnodet, jbonofre
  */
 public class InterpolationHelper {
 

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/amqp/AmqpHeader.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/amqp/AmqpHeader.java
@@ -21,7 +21,6 @@ import org.vertx.java.core.buffer.Buffer;
 import static io.fabric8.gateway.handlers.detecting.protocol.BufferSupport.startsWith;
 
 /**
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class AmqpHeader {
 

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/OpenwireException.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/OpenwireException.java
@@ -17,7 +17,6 @@
 package io.fabric8.gateway.handlers.detecting.protocol.openwire;
 
 /**
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class OpenwireException extends RuntimeException {
 

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/command/BooleanExpression.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/command/BooleanExpression.java
@@ -20,7 +20,6 @@ package io.fabric8.gateway.handlers.detecting.protocol.openwire.command;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface BooleanExpression { // extends org.apache.activemq.apollo.filter.BooleanExpression {
 }

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/command/CachedEncodingTrait.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/command/CachedEncodingTrait.java
@@ -22,7 +22,6 @@ import org.fusesource.hawtbuf.Buffer;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface CachedEncodingTrait {
     boolean tight();

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/support/OpenwireException.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/support/OpenwireException.java
@@ -21,7 +21,6 @@ package io.fabric8.gateway.handlers.detecting.protocol.openwire.support;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class OpenwireException extends Exception {
 

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/support/Settings.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/openwire/support/Settings.java
@@ -21,7 +21,6 @@ package io.fabric8.gateway.handlers.detecting.protocol.openwire.support;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public class Settings {
 

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/stomp/Constants.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/stomp/Constants.java
@@ -21,7 +21,6 @@ import io.fabric8.gateway.handlers.detecting.protocol.Ascii;
 /**
  * Holds STOMP related constants.
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface Constants {
 

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/stomp/StompFrame.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/protocol/stomp/StompFrame.java
@@ -29,7 +29,6 @@ import static io.fabric8.gateway.handlers.detecting.protocol.stomp.Constants.*;
 /**
  * A STOMP protocol frame.
  *
- * @author <a href="http://hiramchirino.com">chirino</a>
  */
 public class StompFrame {
 

--- a/process/process-manager/src/main/java/io/fabric8/process/manager/service/ProcessServiceFactory.java
+++ b/process/process-manager/src/main/java/io/fabric8/process/manager/service/ProcessServiceFactory.java
@@ -41,7 +41,6 @@ import java.util.Map;
 /**
  * A {@link ManagedServiceFactory} for managing processes using {@link io.fabric8.process.manager.ProcessManager ProcessManager}.
  *
- * @author Dhiraj Bokde
  */
 public class ProcessServiceFactory implements ManagedServiceFactory {
 

--- a/runtime/container/common/src/main/java/io/fabric8/runtime/container/ContainerConfiguration.java
+++ b/runtime/container/common/src/main/java/io/fabric8/runtime/container/ContainerConfiguration.java
@@ -29,7 +29,6 @@ import org.jboss.gravia.utils.NotNullException;
 /**
  * The managed container configuration
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public abstract class ContainerConfiguration {

--- a/runtime/container/common/src/main/java/io/fabric8/runtime/container/ContainerConfigurationBuilder.java
+++ b/runtime/container/common/src/main/java/io/fabric8/runtime/container/ContainerConfigurationBuilder.java
@@ -27,7 +27,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed container configuration builder
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public abstract class ContainerConfigurationBuilder {

--- a/runtime/container/common/src/main/java/io/fabric8/runtime/container/LifecycleException.java
+++ b/runtime/container/common/src/main/java/io/fabric8/runtime/container/LifecycleException.java
@@ -3,7 +3,6 @@ package io.fabric8.runtime.container;
 /**
  * LifecycleException
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public class LifecycleException extends Exception

--- a/runtime/container/common/src/main/java/io/fabric8/runtime/container/ManagedContainer.java
+++ b/runtime/container/common/src/main/java/io/fabric8/runtime/container/ManagedContainer.java
@@ -26,7 +26,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed root container
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public interface ManagedContainer<T extends ContainerConfiguration> {

--- a/runtime/container/common/src/main/java/io/fabric8/runtime/container/spi/AbstractManagedContainer.java
+++ b/runtime/container/common/src/main/java/io/fabric8/runtime/container/spi/AbstractManagedContainer.java
@@ -35,7 +35,6 @@ import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 /**
  * The managed root container
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public abstract class AbstractManagedContainer<T extends ContainerConfiguration> implements ManagedContainer<T> {
@@ -191,7 +190,6 @@ public abstract class AbstractManagedContainer<T extends ContainerConfiguration>
 
     /**
      * Runnable that consumes the output of the process. If nothing consumes the output the AS will hang on some platforms
-     * @author Stuart Douglas
      */
     public static class ConsoleConsumer implements Runnable {
 

--- a/runtime/container/karaf/managed/src/main/java/io/fabric8/runtime/container/karaf/KarafContainerConfiguration.java
+++ b/runtime/container/karaf/managed/src/main/java/io/fabric8/runtime/container/karaf/KarafContainerConfiguration.java
@@ -28,7 +28,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed container configuration
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public final class KarafContainerConfiguration extends ContainerConfiguration {

--- a/runtime/container/karaf/managed/src/main/java/io/fabric8/runtime/container/karaf/KarafContainerConfigurationBuilder.java
+++ b/runtime/container/karaf/managed/src/main/java/io/fabric8/runtime/container/karaf/KarafContainerConfigurationBuilder.java
@@ -22,7 +22,6 @@ import io.fabric8.runtime.container.ContainerConfigurationBuilder;
 /**
  * The managed container configuration builder
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public class KarafContainerConfigurationBuilder extends ContainerConfigurationBuilder {

--- a/runtime/container/karaf/managed/src/main/java/io/fabric8/runtime/container/karaf/KarafManagedContainer.java
+++ b/runtime/container/karaf/managed/src/main/java/io/fabric8/runtime/container/karaf/KarafManagedContainer.java
@@ -27,7 +27,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed root container
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public final class KarafManagedContainer extends AbstractManagedContainer<KarafContainerConfiguration> {

--- a/runtime/container/tomcat/managed/src/main/java/io/fabric8/runtime/container/tomcat/TomcatContainerConfiguration.java
+++ b/runtime/container/tomcat/managed/src/main/java/io/fabric8/runtime/container/tomcat/TomcatContainerConfiguration.java
@@ -28,7 +28,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed container configuration
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public final class TomcatContainerConfiguration extends ContainerConfiguration {

--- a/runtime/container/tomcat/managed/src/main/java/io/fabric8/runtime/container/tomcat/TomcatContainerConfigurationBuilder.java
+++ b/runtime/container/tomcat/managed/src/main/java/io/fabric8/runtime/container/tomcat/TomcatContainerConfigurationBuilder.java
@@ -22,7 +22,6 @@ import io.fabric8.runtime.container.ContainerConfigurationBuilder;
 /**
  * The managed container configuration builder
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public class TomcatContainerConfigurationBuilder extends ContainerConfigurationBuilder {

--- a/runtime/container/tomcat/managed/src/main/java/io/fabric8/runtime/container/tomcat/TomcatManagedContainer.java
+++ b/runtime/container/tomcat/managed/src/main/java/io/fabric8/runtime/container/tomcat/TomcatManagedContainer.java
@@ -28,7 +28,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed root container
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public final class TomcatManagedContainer extends AbstractManagedContainer<TomcatContainerConfiguration> {

--- a/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/FabricBootstrapCompleteListener.java
+++ b/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/FabricBootstrapCompleteListener.java
@@ -34,7 +34,6 @@ import org.fusesource.portable.runtime.tomcat.FabricTomcatActivator.BoostrapLatc
 /**
  * Wait until fabric bootstrap is complete.
  *
- * @author thomas.diesler@jboss.com
  * @since 17-Dec-2013
  */
 public class FabricBootstrapCompleteListener implements ServletContextListener {

--- a/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/FabricPropertiesProvider.java
+++ b/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/FabricPropertiesProvider.java
@@ -35,7 +35,6 @@ import org.jboss.gravia.runtime.spi.PropertiesProvider;
 /**
  * The Fabric {@link PropertiesProvider}
  *
- * @author thomas.diesler@jboss.com
  * @since 17-Jan-2014
  */
 public class FabricPropertiesProvider extends TomcatPropertiesProvider {

--- a/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/FabricTomcatActivator.java
+++ b/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/FabricTomcatActivator.java
@@ -58,7 +58,6 @@ import org.jboss.gravia.runtime.spi.RuntimePropertiesProvider;
 /**
  * Activates the {@link Runtime} as part of the web app lifecycle.
  *
- * @author thomas.diesler@jboss.com
  * @since 20-Nov-2013
  */
 public class FabricTomcatActivator implements ServletContextListener {

--- a/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/SecurityActions.java
+++ b/runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/SecurityActions.java
@@ -28,7 +28,6 @@ import java.security.PrivilegedAction;
  * Privileged actions used by this package.
  * No methods in this class are to be made public under any circumstances!
  *
- * @author Thomas.Diesler@jboss.com
  * @since 29-Oct-2010
  */
 final class SecurityActions {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/FabricConstants.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/FabricConstants.java
@@ -28,7 +28,6 @@ import org.jboss.msc.service.ServiceName;
 /**
  * Fabric subsystem constants.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 public interface FabricConstants {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricExtension.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricExtension.java
@@ -30,7 +30,6 @@ import org.jboss.as.controller.parsing.ExtensionParsingContext;
 /**
  * Domain extension used to initialize the Fabric subsystem.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 public final class FabricExtension implements Extension {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricResolvers.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricResolvers.java
@@ -26,7 +26,6 @@ import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 
 /**
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 final class FabricResolvers {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricRootResource.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricRootResource.java
@@ -32,7 +32,6 @@ import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
 /**
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 final class FabricRootResource extends SimpleResourceDefinition {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricSubsystemAdd.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricSubsystemAdd.java
@@ -41,7 +41,6 @@ import org.jboss.gravia.runtime.Runtime;
 /**
  * The fabric subsystem add update handler.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 final class FabricSubsystemAdd extends AbstractBoottimeAddStepHandler {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricSubsystemParser.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricSubsystemParser.java
@@ -40,7 +40,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 /**
  * Parse Fabric subsystem configuration
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 final class FabricSubsystemParser implements Namespace10, XMLStreamConstants, XMLElementReader<List<ModelNode>> {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricSubsystemWriter.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/FabricSubsystemWriter.java
@@ -32,7 +32,6 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
 /**
  * Write Fabric subsystem configuration.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 final class FabricSubsystemWriter implements XMLStreamConstants, XMLElementWriter<SubsystemMarshallingContext> {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/ModelConstants.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/ModelConstants.java
@@ -27,7 +27,6 @@ package org.wildfly.extension.fabric.parser;
 /**
  * Fabric subsystem model constants.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 interface ModelConstants {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/Namespace.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/Namespace.java
@@ -30,7 +30,6 @@ import java.util.Map;
 /**
  * An enumeration of the supported Fabric subsystem namespaces.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 enum Namespace {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/Namespace10.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/Namespace10.java
@@ -30,7 +30,6 @@ import java.util.Map;
 /**
  * Constants related to namespace {@link Namespace#VERSION_1_0}.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 interface Namespace10 {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/SecurityActions.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/SecurityActions.java
@@ -29,7 +29,6 @@ import java.security.PrivilegedAction;
 /**
  * Privileged actions used by this package.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 19-Jan-2010
  */
 class SecurityActions {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/SubsystemState.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/parser/SubsystemState.java
@@ -26,7 +26,6 @@ package org.wildfly.extension.fabric.parser;
 /**
  * The Fabric subsystem state.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 13-Nov-2013
  */
 public final class SubsystemState  {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/service/FabricBootstrapService.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/service/FabricBootstrapService.java
@@ -69,7 +69,6 @@ import org.wildfly.extension.gravia.GraviaConstants;
 /**
  * Service responsible for creating and managing the life-cycle of the gravia subsystem.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 19-Apr-2013
  */
 public class FabricBootstrapService extends AbstractService<ZooKeeperClusterBootstrap> {

--- a/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/service/FabricRuntimeService.java
+++ b/runtime/container/wildfly/extension/src/main/java/org/wildfly/extension/fabric/service/FabricRuntimeService.java
@@ -34,7 +34,6 @@ import org.wildfly.extension.gravia.service.RuntimeService;
 /**
  * Service responsible for creating and managing the life-cycle of the gravia subsystem.
  *
- * @author Thomas.Diesler@jboss.com
  * @since 19-Apr-2013
  */
 public final class FabricRuntimeService extends RuntimeService {

--- a/runtime/container/wildfly/managed/src/main/java/io/fabric8/runtime/container/wildfly/WildFlyContainerConfiguration.java
+++ b/runtime/container/wildfly/managed/src/main/java/io/fabric8/runtime/container/wildfly/WildFlyContainerConfiguration.java
@@ -28,7 +28,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed container configuration
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public final class WildFlyContainerConfiguration extends ContainerConfiguration {

--- a/runtime/container/wildfly/managed/src/main/java/io/fabric8/runtime/container/wildfly/WildFlyContainerConfigurationBuilder.java
+++ b/runtime/container/wildfly/managed/src/main/java/io/fabric8/runtime/container/wildfly/WildFlyContainerConfigurationBuilder.java
@@ -22,7 +22,6 @@ import io.fabric8.runtime.container.ContainerConfigurationBuilder;
 /**
  * The managed container configuration builder
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public class WildFlyContainerConfigurationBuilder extends ContainerConfigurationBuilder {

--- a/runtime/container/wildfly/managed/src/main/java/io/fabric8/runtime/container/wildfly/WildFlyManagedContainer.java
+++ b/runtime/container/wildfly/managed/src/main/java/io/fabric8/runtime/container/wildfly/WildFlyManagedContainer.java
@@ -28,7 +28,6 @@ import org.jboss.gravia.runtime.RuntimeType;
 /**
  * The managed root container
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public final class WildFlyManagedContainer extends AbstractManagedContainer<WildFlyContainerConfiguration> {

--- a/runtime/container/wildfly/webapp/src/main/java/org/fusesource/portable/runtime/wildfly/FabricActivator.java
+++ b/runtime/container/wildfly/webapp/src/main/java/org/fusesource/portable/runtime/wildfly/FabricActivator.java
@@ -35,7 +35,6 @@ import org.osgi.framework.BundleContext;
 /**
  * Initialize the fabric webapp
  *
- * @author thomas.diesler@jboss.com
  * @since 20-Nov-2013
  */
 public class FabricActivator implements ServletContextListener {

--- a/runtime/container/wildfly/webapp/src/main/java/org/fusesource/portable/runtime/wildfly/SecurityActions.java
+++ b/runtime/container/wildfly/webapp/src/main/java/org/fusesource/portable/runtime/wildfly/SecurityActions.java
@@ -28,7 +28,6 @@ import java.security.PrivilegedAction;
  * Privileged actions used by this package.
  * No methods in this class are to be made public under any circumstances!
  *
- * @author Thomas.Diesler@jboss.com
  * @since 29-Oct-2010
  */
 final class SecurityActions {

--- a/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/BootstrapServiceTest.java
+++ b/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/BootstrapServiceTest.java
@@ -47,7 +47,6 @@ import org.junit.runner.RunWith;
 /**
  * Test basic {@link ZooKeeperClusterBootstrap} functionality
  *
- * @author thomas.diesler@jboss.com
  * @since 27-Jan-2014
  */
 @RunWith(Arquillian.class)

--- a/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/ContainerStartupTest.java
+++ b/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/ContainerStartupTest.java
@@ -50,7 +50,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
 /**
  * Test basic {@link FabricService} functionality
  *
- * @author thomas.diesler@jboss.com
  * @since 27-Jan-2014
  */
 @RunWith(Arquillian.class)

--- a/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/FabricCreateCommandTest.java
+++ b/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/FabricCreateCommandTest.java
@@ -49,7 +49,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
 /**
  * Test the fabric:create command
  *
- * @author thomas.diesler@jboss.com
  * @since 03-Feb-2014
  */
 @RunWith(Arquillian.class)

--- a/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/ManagedContainerTest.java
+++ b/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/ManagedContainerTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 /**
  * Test basic {@link ManagedContainer} functionality
  *
- * @author thomas.diesler@jboss.com
  * @since 26-Feb-2014
  */
 public class ManagedContainerTest {

--- a/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/support/CommandSupport.java
+++ b/runtime/itests/common/src/main/java/io/fabric8/runtime/itests/support/CommandSupport.java
@@ -42,7 +42,6 @@ import org.junit.Assert;
 /**
  * Test helper utility
  *
- * @author thomas.diesler@jboss.com
  * @since 03-Feb-2014
  */
 public final class CommandSupport {

--- a/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/BootstrapCompleteTest.java
+++ b/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/BootstrapCompleteTest.java
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith;
 /**
  * Test fabric-core servies
  *
- * @author thomas.diesler@jboss.com
  * @since 21-Oct-2013
  */
 @RunWith(Arquillian.class)

--- a/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/FabricBootstrapTest.java
+++ b/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/FabricBootstrapTest.java
@@ -48,7 +48,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
 /**
  * Test fabric-core servies
  *
- * @author thomas.diesler@jboss.com
  * @since 21-Oct-2013
  */
 @RunWith(Arquillian.class)

--- a/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/support/AbstractEmbeddedTest.java
+++ b/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/support/AbstractEmbeddedTest.java
@@ -37,7 +37,6 @@ import org.junit.BeforeClass;
 /**
  * Test fabric-core servies
  *
- * @author thomas.diesler@jboss.com
  * @since 21-Oct-2013
  */
 public abstract class AbstractEmbeddedTest {

--- a/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/support/EmbeddedUtils.java
+++ b/runtime/itests/embedded/src/test/java/org/fusesource/test/fabric/runtime/embedded/support/EmbeddedUtils.java
@@ -47,7 +47,6 @@ import org.jboss.gravia.runtime.spi.RuntimeFactory;
 /**
  * Utility for embedded runtime tests
  *
- * @author thomas.diesler@jboss.com
  * @since 18-Oct-2013
  */
 public class EmbeddedUtils {

--- a/runtime/itests/karaf/src/test/java/io/fabric8/runtime/itests/karaf/CreateChildContainerTest.java
+++ b/runtime/itests/karaf/src/test/java/io/fabric8/runtime/itests/karaf/CreateChildContainerTest.java
@@ -48,7 +48,6 @@ import org.osgi.util.tracker.ServiceTracker;
 /**
  * Test the fabric:create command
  *
- * @author thomas.diesler@jboss.com
  * @since 04-Feb-2014
  */
 @RunWith(Arquillian.class)

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/BrokerViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/BrokerViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.BrokerViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface BrokerViewFacade extends BrokerViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/ConnectionViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/ConnectionViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.ConnectionViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface ConnectionViewFacade extends ConnectionViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/ConnectorViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/ConnectorViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.ConnectorViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface ConnectorViewFacade extends ConnectorViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/DurableSubscriptionViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/DurableSubscriptionViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.DurableSubscriptionViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface DurableSubscriptionViewFacade extends DurableSubscriptionViewMBean, SubscriptionViewFacade {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/JobSchedulerViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/JobSchedulerViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.JobSchedulerViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface JobSchedulerViewFacade extends JobSchedulerViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/NetworkBridgeViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/NetworkBridgeViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.NetworkBridgeViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface NetworkBridgeViewFacade extends NetworkBridgeViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/NetworkConnectorViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/NetworkConnectorViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.NetworkConnectorViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface NetworkConnectorViewFacade extends NetworkConnectorViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/ProducerViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/ProducerViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.ProducerViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface ProducerViewFacade extends ProducerViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/QueueViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/QueueViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.QueueViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface QueueViewFacade extends QueueViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/SubscriptionViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/SubscriptionViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.SubscriptionViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface SubscriptionViewFacade extends SubscriptionViewMBean {
 

--- a/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/TopicViewFacade.java
+++ b/tooling/tooling-activemq-facade/src/main/java/io/fabric8/activemq/facade/TopicViewFacade.java
@@ -22,7 +22,6 @@ import org.apache.activemq.broker.jmx.TopicViewMBean;
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 public interface TopicViewFacade extends TopicViewMBean {
 

--- a/website/ext/Website.scala
+++ b/website/ext/Website.scala
@@ -23,7 +23,6 @@ package
  * <p>
  * </p>
  *
- * @author <a href="http://hiramchirino.com">Hiram Chirino</a>
  */
 object Website {
 


### PR DESCRIPTION
removed all instance except for @author left behind in kinana js file and a few jboss comments. 

These are the only files that remain with @author.

``` javascript
insight/insight-kibana3/src/main/webapp/common/lib/angular-strap.min.js: * @author Olivier Louvignes
runtime/container/tomcat/webapp/src/main/java/org/fusesource/portable/runtime/tomcat/FabricServlet.java: * as indicated by the @author tags. See the copyright.txt file in the
runtime/container/wildfly/webapp/src/main/java/org/fusesource/portable/runtime/wildfly/FabricServlet.java: * as indicated by the @author tags. See the copyright.txt file in the
```
