### PR TITLE
Downgrade to xbean 3.16 as 3.17 requires asm5. Why the fuck did they not...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <wagon-webdav-plugin-version>1.0-beta-7</wagon-webdav-plugin-version>
         <wildfly-version>8.0.0.Beta1</wildfly-version>
         <xalan.version>2.7.1</xalan.version>
-        <xbean-version>3.17</xbean-version>
+        <xbean-version>3.16</xbean-version>
         <xerces.version>2.11.0</xerces.version>
         <xjc-version>2.1.10.1</xjc-version>
         <xml.api.version>2.11.0-20110622</xml.api.version>


### PR DESCRIPTION
... call the release 4.0?
