### PR TITLE
Fixes ENTMQ-628 - Replicated fabric8 mq nodes should not register in fab...

### DIFF
--- a/mq/mq-fabric/src/main/scala/io/fabric8/mq/fabric/ActiveMQServiceFactory.scala
+++ b/mq/mq-fabric/src/main/scala/io/fabric8/mq/fabric/ActiveMQServiceFactory.scala
@@ -266,7 +266,6 @@ class ActiveMQServiceFactory(bundleContext: BundleContext) extends ManagedServic
             discoveryAgent.setGroupName(group)
             discoveryAgent.setCurator(curator)
             if (replicating) {
-              discoveryAgent.start()
               if (started.compareAndSet(false, true)) {
                 info("Replicating broker %s is starting.", name)
                 start()
@@ -451,6 +450,11 @@ class ActiveMQServiceFactory(bundleContext: BundleContext) extends ManagedServic
             }
           }
         })
+
+        // we only register once broker startup has completed.
+        if( replicating ) {
+          discoveryAgent.start()
+        }
 
         // Update the advertised endpoint URIs that clients can use.
         if (!standalone || replicating) {


### PR DESCRIPTION
Replicated fabric8 mq nodes should not register in fabric discovery until they become a master.
