### PR TITLE
Initial commit of Spring Boot jar processes support

### DIFF
--- a/process/pom.xml
+++ b/process/pom.xml
@@ -36,6 +36,7 @@
         <module>process-packaging</module>
         <module>process-manager</module>
         <module>process-fabric</module>
+        <module>process-spring-boot</module>
         <module>samples</module>
     </modules>
 

--- a/process/process-spring-boot/pom.xml
+++ b/process/process-spring-boot/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.fabric8</groupId>
+        <artifactId>process-project</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>process-spring-boot</artifactId>
+    <packaging>pom</packaging>
+    
+    <name>Fabric8 :: Process :: Spring Boot</name>
+
+    <properties>
+        <spring-boot-version>1.0.1.RELEASE</spring-boot-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>${spring-boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>process-spring-boot-container</module>
+    </modules>
+
+</project>

--- a/process/process-spring-boot/process-spring-boot-container/pom.xml
+++ b/process/process-spring-boot/process-spring-boot-container/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.fabric8</groupId>
+        <artifactId>process-spring-boot</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>process-spring-boot-container</artifactId>
+
+    <name>Fabric8 :: Process :: Spring Boot :: Container</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplication.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplication.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.process.spring.boot.container;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Executable Java class to be used as a base for the Fabric-managed Spring Boot applications. Auto-detects and loads
+ * Fabric- and JBoss- related Boot starters.
+ */
+public class FabricSpringApplication {
+
+    public static void main(String[] args) {
+        run(args);
+    }
+
+    public static ConfigurableApplicationContext run(String[] args) {
+        return SpringApplication.run(FabricSpringApplicationConfiguration.class, args);
+    }
+
+}

--- a/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationConfiguration.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationConfiguration.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.process.spring.boot.container;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Detects Boot starters distributed with Fabric.
+ *
+ */
+@ComponentScan("io.fabric8")
+@Configuration
+public class FabricSpringApplicationConfiguration {
+}

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/TestStarterBean.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/TestStarterBean.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8;
+
+public class TestStarterBean {
+}

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/TestStarterConfiguration.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/TestStarterConfiguration.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestStarterConfiguration {
+
+    @Bean
+    TestStarterBean testStarterBean() {
+        return new TestStarterBean();
+    }
+
+}

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationTest.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.process.spring.boot.container;
+
+import io.fabric8.TestStarterBean;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+
+public class FabricSpringApplicationTest extends Assert {
+
+    @Test
+    public void shouldLoadFabricStarterConfiguration() {
+        // When
+        ApplicationContext applicationContext = FabricSpringApplication.run(new String[0]);
+        TestStarterBean testStarterBean = applicationContext.getBean(TestStarterBean.class);
+
+        // Then
+        assertNotNull(testStarterBean);
+    }
+
+}


### PR DESCRIPTION
Hi,

I created a base support for Spring Boot based jar processes. My application class makes installing such jars via `process-install-jar` a bit easier. I plan to extend Spring Boot support for installed jars, so people could use our stuff (Camel, AMQ, access ZooKeeper registry, etc) in the Spring Boot way i.e. following the convention over configuration approach.

In general as Spring Boot is very opinionated in the regards of its usage, we should provide opinionated Fabric/Camel/AMQ integration as well.

Cheers.
