### PR TITLE
Downgrade to jclouds 1.7.1 as 1.7.2 causes Maven to download SNAPSHOT de...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,8 +193,8 @@
         <jasypt-version>1.9.1</jasypt-version>
         <jaxb-api-version>2.1</jaxb-api-version>
         <jaxb-version>2.2.6</jaxb-version>
-        <jclouds-karaf-version>1.7.2</jclouds-karaf-version>
-        <jclouds-version>1.7.2</jclouds-version>
+        <jclouds-karaf-version>1.7.1</jclouds-karaf-version>
+        <jclouds-version>1.7.1</jclouds-version>
         <jclouds.osgi.version.clean>${jclouds-version}</jclouds.osgi.version.clean>
         <jersey-version>1.18.1</jersey-version>
         <jettison.version>1.3.5</jettison.version>


### PR DESCRIPTION
...pendencies which CI server fails the build in the end.
