### PR TITLE
Added automatic routes loading to the Camel Spring Boot starter

### DIFF
--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/main/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfiguration.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/main/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfiguration.java
@@ -17,6 +17,7 @@
 package io.fabric8.process.spring.boot.starter.camel;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.RoutesBuilder;
 import org.apache.camel.spring.SpringCamelContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -29,9 +30,18 @@ public class CamelAutoConfiguration {
     @Autowired
     private ApplicationContext applicationContext;
 
+    @Autowired(required = false)
+    private RoutesBuilder[] routesBuilders;
+
     @Bean
-    public CamelContext camelContext() {
-        return new SpringCamelContext(applicationContext);
+    public CamelContext camelContext() throws Exception {
+        CamelContext camelContext = new SpringCamelContext(applicationContext);
+        if (routesBuilders != null) {
+            for (RoutesBuilder routesBuilder : routesBuilders) {
+                camelContext.addRoutes(routesBuilder);
+            }
+        }
+        return camelContext;
     }
 
 }

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
@@ -18,6 +18,7 @@ package io.fabric8.process.spring.boot.starter.camel;
 
 import io.fabric8.process.spring.boot.container.FabricSpringApplication;
 import org.apache.camel.CamelContext;
+import org.apache.camel.Route;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -32,6 +33,17 @@ public class CamelAutoConfigurationTest extends Assert {
 
         // Then
         assertNotNull(camelContext);
+    }
+
+    @Test
+    public void shouldDetectRoutes() {
+        // When
+        ApplicationContext applicationContext = FabricSpringApplication.run(new String[0]);
+        CamelContext camelContext = applicationContext.getBean(CamelContext.class);
+        Route route = camelContext.getRoute("test");
+
+        // Then
+        assertNotNull(route);
     }
 
 }

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/TestRoutesConfiguration.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/TestRoutesConfiguration.java
@@ -1,0 +1,20 @@
+package io.fabric8.process.spring.boot.starter.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TestRoutesConfiguration {
+
+    @Bean
+    RouteBuilder routeBuilder() {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:test").routeId("test").to("mock:test");
+            }
+        };
+    }
+
+}

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/resources/META-INF/spring.factories
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.fabric8.process.spring.boot.starter.camel.TestRoutesConfiguration


### PR DESCRIPTION
Camel Spring Boot starter now automatically loads all beans implementing `RoutesBuilder` interface.
