### PR TITLE
[Spring Boot] Added business-level component scanning.

### DIFF
--- a/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/ComponentScanningApplicationContextInitializer.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/ComponentScanningApplicationContextInitializer.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.process.spring.boot.container;
+
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
+
+public class ComponentScanningApplicationContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    public static final String BASE_PACKAGE_PROPERTY_KEY = "io.fabric8.process.spring.boot.container.basepackage";
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        String basePackage = System.getProperty(BASE_PACKAGE_PROPERTY_KEY);
+        if (basePackage != null) {
+            ClassPathBeanDefinitionScanner scanner = new ClassPathBeanDefinitionScanner((BeanDefinitionRegistry) applicationContext, true);
+            scanner.setResourceLoader(applicationContext);
+            scanner.scan(basePackage);
+        }
+    }
+
+}

--- a/process/process-spring-boot/process-spring-boot-container/src/main/resources/META-INF/spring.factories
+++ b/process/process-spring-boot/process-spring-boot-container/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.context.ApplicationContextInitializer=\
+io.fabric8.process.spring.boot.container.ComponentScanningApplicationContextInitializer

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationTest.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationTest.java
@@ -21,12 +21,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 
+import static io.fabric8.process.spring.boot.container.ComponentScanningApplicationContextInitializer.BASE_PACKAGE_PROPERTY_KEY;
 import static io.fabric8.process.spring.boot.container.FabricSpringApplication.NO_ARGUMENTS;
 
 public class FabricSpringApplicationTest extends Assert {
 
     @Test
     public void shouldLoadFabricStarterConfiguration() {
+        // Given
+        System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8");
+
         // When
         ApplicationContext applicationContext = FabricSpringApplication.run(NO_ARGUMENTS);
         TestStarterBean testStarterBean = applicationContext.getBean(TestStarterBean.class);

--- a/process/process-spring-boot/process-spring-boot-container/src/test/resources/META-INF/spring.factories
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-io.fabric8.TestStarterConfiguration

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 
+import static io.fabric8.process.spring.boot.container.ComponentScanningApplicationContextInitializer.BASE_PACKAGE_PROPERTY_KEY;
 import static io.fabric8.process.spring.boot.starter.camel.TestRoutesConfiguration.ROUTE_ID;
 
 public class CamelAutoConfigurationTest extends Assert {
@@ -39,6 +40,9 @@ public class CamelAutoConfigurationTest extends Assert {
 
     @Test
     public void shouldDetectRoutes() {
+        // Given
+        System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8.process.spring.boot.starter.camel");
+
         // When
         ApplicationContext applicationContext = FabricSpringApplication.run(new String[0]);
         CamelContext camelContext = applicationContext.getBean(CamelContext.class);

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/resources/META-INF/spring.factories
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-io.fabric8.process.spring.boot.starter.camel.TestRoutesConfiguration


### PR DESCRIPTION
Now folks can enable scanning of their business components by setting `io.fabric8.process.spring.boot.container.basepackage` system property on the deployed Spring Boot jar:

```
java -jar my-fabric-managed-spring-boot-app.jar -Dio.fabric8.process.spring.boot.container.basepackage=com.company.project
```

Thanks to this, no custom wiring is needed in order to load project-level components in Fabric-managed Spring Boot jars.
