### PR TITLE
[Spring Boot] Added web support detection / force flag

### DIFF
--- a/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplication.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplication.java
@@ -16,8 +16,10 @@
  */
 package io.fabric8.process.spring.boot.container;
 
-import org.springframework.boot.SpringApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
+
+import static java.lang.Boolean.parseBoolean;
 
 /**
  * Executable Java class to be used as a base for the Fabric-managed Spring Boot applications. Auto-detects and loads
@@ -25,14 +27,34 @@ import org.springframework.context.ConfigurableApplicationContext;
  */
 public class FabricSpringApplication {
 
+    public static final String WEB_PROPERTY_KEY = "io.fabric8.process.spring.boot.container.web";
+
     public static final String[] NO_ARGUMENTS = new String[0];
 
-    public static void main(String[] args) {
-        run(args);
+    private Boolean web;
+
+    public ConfigurableApplicationContext run(String... args) {
+        SpringApplicationBuilder applicationBuilder = new SpringApplicationBuilder().
+                sources(FabricSpringApplicationConfiguration.class);
+
+        // Check of the web system property should be performed by the Spring Boot - we should issue PR for this.
+        String webSystemProperty = System.getProperty(WEB_PROPERTY_KEY);
+        if(webSystemProperty != null) {
+            applicationBuilder.web(parseBoolean(webSystemProperty));
+        } else if(web != null) {
+            applicationBuilder.web(web);
+        }
+
+        return  applicationBuilder.run(args);
     }
 
-    public static ConfigurableApplicationContext run(String[] args) {
-        return SpringApplication.run(FabricSpringApplicationConfiguration.class, args);
+    public static void main(String[] args) {
+        new FabricSpringApplication().run(args);
+    }
+
+    public FabricSpringApplication web(boolean web) {
+        this.web = web;
+        return this;
     }
 
 }

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationTest.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/FabricSpringApplicationTest.java
@@ -23,7 +23,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static io.fabric8.process.spring.boot.container.ComponentScanningApplicationContextInitializer.BASE_PACKAGE_PROPERTY_KEY;
-import static io.fabric8.process.spring.boot.container.FabricSpringApplication.NO_ARGUMENTS;
 
 @Configuration
 public class FabricSpringApplicationTest extends Assert {
@@ -43,7 +42,7 @@ public class FabricSpringApplicationTest extends Assert {
         System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8");
 
         // When
-        ApplicationContext applicationContext = FabricSpringApplication.run(NO_ARGUMENTS);
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
         TestStarterBean testStarterBean = applicationContext.getBean(TestStarterBean.class);
 
         // Then
@@ -56,7 +55,7 @@ public class FabricSpringApplicationTest extends Assert {
         System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8");
 
         // When
-        ApplicationContext applicationContext = FabricSpringApplication.run(NO_ARGUMENTS);
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
         String testScopedBean = applicationContext.getBean(String.class);
 
         // Then

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
@@ -31,7 +31,7 @@ public class CamelAutoConfigurationTest extends Assert {
     @Test
     public void shouldCreateCamelContext() {
         // When
-        ApplicationContext applicationContext = FabricSpringApplication.run(new String[0]);
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
         CamelContext camelContext = applicationContext.getBean(CamelContext.class);
 
         // Then
@@ -44,7 +44,7 @@ public class CamelAutoConfigurationTest extends Assert {
         System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8.process.spring.boot.starter.camel");
 
         // When
-        ApplicationContext applicationContext = FabricSpringApplication.run(new String[0]);
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
         CamelContext camelContext = applicationContext.getBean(CamelContext.class);
         Route route = camelContext.getRoute(ROUTE_ID);
 


### PR DESCRIPTION
Spring Boot web profile autodetection can be now overridden with the boolean system property `io.fabric8.process.spring.boot.container.web`. This option will be useful if user would like to override web nature of the process on the Fabric level (via fabric profile for example).

We can also explicitly set the web nature of the application on the `FabricSpringApplication` builder level.
