### PR TITLE
[Spring Boot] Added pre-configured Camel templates.

### DIFF
--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/main/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfiguration.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/main/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfiguration.java
@@ -17,6 +17,8 @@
 package io.fabric8.process.spring.boot.starter.camel;
 
 import org.apache.camel.CamelContext;
+import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.ProducerTemplate;
 import org.apache.camel.RoutesBuilder;
 import org.apache.camel.spring.SpringCamelContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +44,7 @@ public class CamelAutoConfiguration {
      * context.
      */
     @Bean
-    public CamelContext camelContext() throws Exception {
+    CamelContext camelContext() throws Exception {
         CamelContext camelContext = new SpringCamelContext(applicationContext);
         if (routesBuilders != null) {
             for (RoutesBuilder routesBuilder : routesBuilders) {
@@ -50,6 +52,16 @@ public class CamelAutoConfiguration {
             }
         }
         return camelContext;
+    }
+
+    @Bean
+    ProducerTemplate producerTemplate() throws Exception {
+        return camelContext().createProducerTemplate();
+    }
+
+    @Bean
+    ConsumerTemplate consumerTemplate() throws Exception {
+        return camelContext().createConsumerTemplate();
     }
 
 }

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
@@ -18,6 +18,8 @@ package io.fabric8.process.spring.boot.starter.camel;
 
 import io.fabric8.process.spring.boot.container.FabricSpringApplication;
 import org.apache.camel.CamelContext;
+import org.apache.camel.ConsumerTemplate;
+import org.apache.camel.ProducerTemplate;
 import org.apache.camel.Route;
 import org.junit.Assert;
 import org.junit.Test;
@@ -50,6 +52,43 @@ public class CamelAutoConfigurationTest extends Assert {
 
         // Then
         assertNotNull(route);
+    }
+
+    @Test
+    public void shouldLoadProducerTemplate() {
+        // When
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
+        ProducerTemplate producerTemplate = applicationContext.getBean(ProducerTemplate.class);
+
+        // Then
+        assertNotNull(producerTemplate);
+    }
+
+    @Test
+    public void shouldLoadConsumerTemplate() {
+        // When
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
+        ConsumerTemplate consumerTemplate = applicationContext.getBean(ConsumerTemplate.class);
+
+        // Then
+        assertNotNull(consumerTemplate);
+    }
+
+    @Test
+    public void shouldSendAndReceiveMessageWithTemplates() {
+        // Given
+        String message = "message";
+        String seda = "seda:test";
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
+        ProducerTemplate producerTemplate = applicationContext.getBean(ProducerTemplate.class);
+        ConsumerTemplate consumerTemplate = applicationContext.getBean(ConsumerTemplate.class);
+
+        // When
+        producerTemplate.sendBody(seda, message);
+        String receivedBody = consumerTemplate.receiveBody(seda, String.class);
+
+        // Then
+        assertEquals(message, receivedBody);
     }
 
 }


### PR DESCRIPTION
Camel Spring Boot starter now provides consumer and producer templates.

We should make them configurable (cache size for example) via properties in the next commits.
