### PR TITLE
[Spring Boot] Added embedded FabricSpringApplication

### DIFF
--- a/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/EmbeddedFabricSpringApplication.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/EmbeddedFabricSpringApplication.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.process.spring.boot.container;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class EmbeddedFabricSpringApplication implements ApplicationContextAware {
+
+    private ConfigurableApplicationContext context;
+
+    public ConfigurableApplicationContext context() {
+        return context;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext parent) throws BeansException {
+        context = new FabricSpringApplication().parent((ConfigurableApplicationContext) parent).run();
+    }
+
+}

--- a/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplication.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/main/java/io/fabric8/process/spring/boot/container/FabricSpringApplication.java
@@ -36,6 +36,8 @@ public class FabricSpringApplication {
 
     // DSL state
 
+    private ConfigurableApplicationContext parent;
+
     private Boolean web;
 
     // Context factory method
@@ -43,8 +45,11 @@ public class FabricSpringApplication {
     public ConfigurableApplicationContext run(String... args) {
         SpringApplicationBuilder applicationBuilder = new SpringApplicationBuilder().
                 sources(FabricSpringApplicationConfiguration.class);
-       resolveWebEnvironment(applicationBuilder);
-        return  applicationBuilder.run(args);
+        if(parent != null) {
+            applicationBuilder.parent(parent);
+        }
+        resolveWebEnvironment(applicationBuilder);
+        return applicationBuilder.run(args);
     }
 
     // Main method
@@ -66,6 +71,11 @@ public class FabricSpringApplication {
     }
 
     // DSL setters
+
+    public FabricSpringApplication parent(ConfigurableApplicationContext parent) {
+        this.parent = parent;
+        return this;
+    }
 
     public FabricSpringApplication web(boolean web) {
         this.web = web;

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/embedded/EmbeddedFabricSpringApplicationTest.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/embedded/EmbeddedFabricSpringApplicationTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) FuseSource, Inc.
+ * http://fusesource.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.process.spring.boot.container.embedded;
+
+import io.fabric8.process.spring.boot.container.EmbeddedFabricSpringApplication;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EmbeddedFabricSpringApplicationTest extends Assert {
+
+    // Test beans
+
+    @Bean
+    String testScopedBean() {
+        return "testScopedBean";
+    }
+
+    @Bean
+    EmbeddedFabricSpringApplication embeddedFabricApplicationContext() {
+        return new EmbeddedFabricSpringApplication();
+    }
+
+    // Tests
+
+    @Test
+    public void shouldLoadParentBean() {
+        // Given
+        ConfigurableApplicationContext parent = new AnnotationConfigApplicationContext(getClass());
+
+        // When
+        ApplicationContext embeddedFabricContext = parent.getBean(EmbeddedFabricSpringApplication.class).context();
+        String testScopedBean = embeddedFabricContext.getBean(String.class);
+
+        // Then
+        assertNotNull(testScopedBean);
+    }
+
+}

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/simple/FabricSpringApplicationTest.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/simple/FabricSpringApplicationTest.java
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.process.spring.boot.container;
+package io.fabric8.process.spring.boot.container.simple;
 
+import io.fabric8.process.spring.boot.container.FabricSpringApplication;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -39,7 +40,7 @@ public class FabricSpringApplicationTest extends Assert {
     @Test
     public void shouldLoadFabricStarterConfiguration() {
         // Given
-        System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8");
+        System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8.process.spring.boot.container.simple");
 
         // When
         ApplicationContext applicationContext = new FabricSpringApplication().run();
@@ -52,7 +53,7 @@ public class FabricSpringApplicationTest extends Assert {
     @Test
     public void shouldLoadTestScopedBean() {
         // Given
-        System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8");
+        System.setProperty(BASE_PACKAGE_PROPERTY_KEY, "io.fabric8.process.spring.boot.container.simple");
 
         // When
         ApplicationContext applicationContext = new FabricSpringApplication().run();

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/simple/TestStarterBean.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/simple/TestStarterBean.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.process.spring.boot.container;
+package io.fabric8.process.spring.boot.container.simple;
 
 public class TestStarterBean {
 }

--- a/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/simple/TestStarterConfiguration.java
+++ b/process/process-spring-boot/process-spring-boot-container/src/test/java/io/fabric8/process/spring/boot/container/simple/TestStarterConfiguration.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.process.spring.boot.container;
+package io.fabric8.process.spring.boot.container.simple;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
Sometimes users may like to embed our Fabric application into existing Spring context (for example to use `io.fabric8.process.spring.boot.container.web` system property is all Fabric-managed jar processes). `EmbeddedFabricSpringApplication` can be easily added as a bean to existing Spring contexts (with one-liner bean definition) and it will automatically start Fabric Spring Boot as a child context.
