### PR TITLE
[Spring Boot] Added predefined TypeConverter to Camel starter.

### DIFF
--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/main/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfiguration.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/main/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.RoutesBuilder;
+import org.apache.camel.TypeConverter;
 import org.apache.camel.spring.SpringCamelContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -62,6 +63,11 @@ public class CamelAutoConfiguration {
     @Bean
     ConsumerTemplate consumerTemplate() throws Exception {
         return camelContext().createConsumerTemplate();
+    }
+
+    @Bean
+    TypeConverter typeConverter() throws Exception {
+        return camelContext().getTypeConverter();
     }
 
 }

--- a/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
+++ b/process/process-spring-boot/process-spring-boot-starter-camel/src/test/java/io/fabric8/process/spring/boot/starter/camel/CamelAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.Route;
+import org.apache.camel.TypeConverter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.context.ApplicationContext;
@@ -89,6 +90,20 @@ public class CamelAutoConfigurationTest extends Assert {
 
         // Then
         assertEquals(message, receivedBody);
+    }
+
+    @Test
+    public void shouldLoadTypeConverters() {
+        // Given
+        Long hundred = 100L;
+        ApplicationContext applicationContext = new FabricSpringApplication().run();
+        TypeConverter typeConverter = applicationContext.getBean(TypeConverter.class);
+
+        // When
+        Long convertedLong = typeConverter.convertTo(Long.class, hundred.toString());
+
+        // Then
+        assertEquals(hundred, convertedLong);
     }
 
 }


### PR DESCRIPTION
Now end-users can just inject Camel's `TypeConverter` into their beans:

```
@Autowired
TypeConverter typeConverter;
...
long hundred = typeConverter.convert(Long.class, "100");
```
