### PR TITLE
Fix http conf which must not be updated if https only is used

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/service/KarafContainerRegistration.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/KarafContainerRegistration.java
@@ -286,15 +286,16 @@ public final class KarafContainerRegistration extends AbstractComponent implemen
         int httpConnectionPort = httpsEnabled && !httpEnabled ? getHttpsConnectionPort(container) : getHttpConnectionPort(container);
         String httpUrl = getHttpUrl(protocol, container.getId(), httpConnectionPort);
         setData(curator.get(), CONTAINER_HTTP.getPath(container.getId()), httpUrl);
+        Configuration configuration = configAdmin.get().getConfiguration(HTTP_PID, null);
         if(httpEnabled){
         	int httpPort = getHttpPort(container);
         	fabricService.get().getPortService().registerPort(container, HTTP_PID, HTTP_BINDING_PORT_KEY, httpPort);
-        	Configuration configuration = configAdmin.get().getConfiguration(HTTP_PID, null);
         	updateIfNeeded(configuration, HTTP_BINDING_PORT_KEY, httpPort);
         }
         if(httpsEnabled){
         	int httpsPort = getHttpsPort(container);
         	fabricService.get().getPortService().registerPort(container, HTTP_PID, HTTPS_BINDING_PORT_KEY, httpsPort);
+        	updateIfNeeded(configuration, HTTPS_BINDING_PORT_KEY, httpsPort);
         }
     }
 


### PR DESCRIPTION
This patch fix the following use case:
- start fabric8
- add a profile which setup https only pax web
- remove the previous profile

--> the pax web conf is back to http but the http port is now the previous https one which is not good.

Best,
Jerome
