### PR TITLE
Fixed ProcessController threads deadlock.

### DIFF
--- a/process/process-manager/src/main/java/io/fabric8/process/manager/support/DefaultProcessController.java
+++ b/process/process-manager/src/main/java/io/fabric8/process/manager/support/DefaultProcessController.java
@@ -137,7 +137,7 @@ public class DefaultProcessController implements ProcessController
 
     public Executor getExecutor() {
     	if (executor == null) {
-    	    executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setDaemon(true).setNameFormat("fuse-process-controller-%s").build());
+    	    executor = Executors.newFixedThreadPool(2, new ThreadFactoryBuilder().setDaemon(true).setNameFormat("fuse-process-controller-%s").build());
     	}
         return executor;
     }

--- a/process/process-manager/src/test/java/io/fabric8/process/manager/support/DefaultProcessControllerTest.java
+++ b/process/process-manager/src/test/java/io/fabric8/process/manager/support/DefaultProcessControllerTest.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2005-2014 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.process.manager.support;
+
+import io.fabric8.process.manager.InstallOptions;
+import io.fabric8.process.manager.config.ProcessConfig;
+import io.fabric8.process.manager.service.ProcessManagerService;
+import io.fabric8.process.manager.support.command.CommandFailedException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static java.util.UUID.randomUUID;
+
+public class DefaultProcessControllerTest {
+
+    File installDir = new File("target", randomUUID().toString());
+
+    DefaultProcessController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("java.protocol.handler.pkgs", "org.ops4j.pax.url");
+
+        InstallOptions installOptions = new InstallOptions.InstallOptionsBuilder().build();
+        String processId = new ProcessManagerService(installDir).installJar(installOptions).getId();
+        controller = new DefaultProcessController(processId, new ProcessConfig(), new File(installDir, processId));
+    }
+
+    @Test(expected = CommandFailedException.class)
+    public void shouldFailedToRunLaunchScriptWithoutMainClass() throws Exception {
+        // Null command == launch script
+        controller.runConfigCommandValueOrLaunchScriptWith(null, "start");
+    }
+
+}


### PR DESCRIPTION
Hi,

While playing with new Java Container I experienced `container-create-child` fabric command hanging from time to time. 

I've debugged it a little bit and found out that `DefaultProcessController#getExecutor()` method returns `newSingleThreadExecutor`. While the same instance of the executor is used to execute the process (`bin/launcher start` in my case) and to asynchronously handle the output of that process (in `OutputProcessor#start()`), it may leads to the deadlock because single thread of executor is supposed to monitor process output and executing the process itself. Finishing execution of the failing process requires to collect the output of that process (in order to display it) - that is the root cause of the deadlock.

I changed the `DefaultProcessController#getExecutor()` default `newSingleThreadExecutor`  to `Executors.newFixedThreadPool(2, ... )`, because two threads is the minimal size of the pool we need to avoid process execution and output processing deadlocks.

Cheers.
