### PR TITLE
[Process manager] Provided dependencies shouldn't be copied.

### DIFF
--- a/process/process-manager/src/main/java/io/fabric8/process/manager/support/JarInstaller.java
+++ b/process/process-manager/src/main/java/io/fabric8/process/manager/support/JarInstaller.java
@@ -26,6 +26,8 @@ import io.fabric8.fab.DependencyTreeResult;
 import io.fabric8.fab.MavenResolverImpl;
 import io.fabric8.process.manager.InstallOptions;
 import io.fabric8.process.manager.config.ProcessConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonatype.aether.artifact.Artifact;
 import org.sonatype.aether.graph.Dependency;
 import org.sonatype.aether.graph.DependencyNode;
@@ -46,6 +48,8 @@ import static io.fabric8.common.util.Strings.join;
 /**
  */
 public class JarInstaller {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JarInstaller.class);
 
     MavenResolverImpl mavenResolver = new MavenResolverImpl();
     private final Executor executor;
@@ -134,6 +138,10 @@ public class JarInstaller {
         List<DependencyNode> children = dependency.getChildren();
         if (children != null) {
             for (DependencyNode child : children) {
+                if(child.getDependency().getScope().equals("provided")) {
+                    LOG.debug("Dependency {} has scope provided. Not copying.", child.getDependency());
+                    continue;
+                }
                 File file = getFile(child);
                 if (file == null) {
                     System.out.println("Cannot find file for dependent jar " + child);


### PR DESCRIPTION
Hi @jstrachan,

We shouldn't install transitive dependencies with `provided` scope. Provided dependencies should be specified using `InstallOptions#optionalDependencyPatterns`.

Many projects include `provided` dependencies instead of `optional`. That results in fabric8 process manager installing a hell lots of conflicting jars. For  example Spring Data comes with all the versions of the JPA API defined in the POM with `provided` scope. Depending on what is eventually found in classpath, Spring Data behaves differently. Currently our process manager will install of these `provided` JPA API jar, what is a total disaster for the executed application :) .

As `provided` dependencies should be explicitly deployed by users, we should let folks to do it via the `InstallOptions#optionalDependencyPatterns`.

Cheers.
