### PR TITLE
[Process manager] Redirect process output to log files

### DIFF
--- a/process/process-launcher/src/main/distro/bin/launcher
+++ b/process/process-launcher/src/main/distro/bin/launcher
@@ -18,8 +18,6 @@
 
 APP_USER=""
 SERVICE="process"
-APP_CONSOLE_OUT="/dev/null"
-APP_CONSOLE_ERR="/dev/null"
 
 #
 # Discover the APP_BASE from the location of this script.
@@ -51,6 +49,10 @@ if [ -z "$APP_BASE" ] ; then
   export APP_BASE
 fi
 PID_FILE="${APP_BASE}/var/${SERVICE}.pid"
+
+# Redirect process output to log files
+APP_CONSOLE_OUT="${APP_BASE}/logs/out.log"
+APP_CONSOLE_ERR="${APP_BASE}/logs/err.log"
 
 # Add the jars in the lib dir
 CLASSPATH=""


### PR DESCRIPTION
Currently we swallow process std and err into `/dev/null`. Operation guys will hate us for this ;) .

I redirected to process logs into the existing `logs` directory. It's a lifesaver when you deploy the process for the first time :) .
