### PR TITLE
Fixed improper use of String.replaceAll

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/service/ComponentConfigurer.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/ComponentConfigurer.java
@@ -95,7 +95,7 @@ public class ComponentConfigurer extends AbstractComponent implements Configurer
             String toReplace = String.format(BOX_FORMAT, name);
             String replacement = properties.getProperty(name);
             replacement = Strings.isNotBlank(replacement) ? replacement : "";
-            result = result.replaceAll(toReplace, replacement);
+            result = result.replaceAll(toReplace, Matcher.quoteReplacement(replacement));
         }
         return result;
     }


### PR DESCRIPTION
On Windows, this caused ${karaf.home} to be replaced with "C:someDirSomeSubDir" instead of ("C:\someDir\SomeSubDir")

When using replaceAll, if the replacement isn't a hardcoded regexp replacement expression, it should be quoted with Matcher.quoteReplacement, otherwise replaceAll will evaluate \0 as a a backreference. Also, it will simply remove backslashes when \x (or \a or \b or ...) is not a special escape sequence as far as replaceAll is concerned.
