### PR TITLE
Add a mvel URL handler to fabric-core + quick doc

### DIFF
--- a/docs/urlHandlers.md
+++ b/docs/urlHandlers.md
@@ -41,6 +41,27 @@ bundle.foo = blueprint:profile:foo.xml
 bundle.bar = spring:profile:bar.xml
 ```
 
+### mvel
+
+The **mvel:** URL handler allow you to render templates based on the effective profile or runtime properties. The profile object can be access using the "profile" variable
+and the runtime properties using the "runtime" one.
+
+e.g.
+
+```
+mvel:profile:jetty.xml
+```
+will refer to the template file called "jetty.xml" either in the current profile or in a parent profiles directory.
+
+If you need more information about the mvel language, please visit http://mvel.codehaus.org/
+
+As for the profile URL handler, you can then startup blueprint or spring XML files as a bundle using this URL with the blueprint or spring URL handlers
+
+```
+bundle.foo = blueprint:mvel:profile:foo.xml
+bundle.bar = spring:mvel:profile:bar.xml
+```
+
 ### zk
 
 The **zk:** URL handler lets you refer to a path in ZooKeeper like you can with file: or http:.

--- a/fabric/fabric-core/pom.xml
+++ b/fabric/fabric-core/pom.xml
@@ -71,6 +71,7 @@
             OSGI-INF/io.fabric8.service.FabricServiceImpl.xml,
             OSGI-INF/io.fabric8.service.PortPlaceholderResolver.xml,
             OSGI-INF/io.fabric8.service.ProfilePropertyPointerResolver.xml,
+            OSGI-INF/io.fabric8.service.MvelUrlHandler.xml,
             OSGI-INF/io.fabric8.service.ProfileUrlHandler.xml,
             OSGI-INF/io.fabric8.service.VersionPropertyPointerResolver.xml,
             OSGI-INF/io.fabric8.service.ZookeeperPlaceholderResolver.xml,
@@ -123,6 +124,10 @@
         <dependency>
             <groupId>org.jasypt</groupId>
             <artifactId>jasypt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mvel</groupId>
+            <artifactId>mvel2</artifactId>
         </dependency>
         
         <!-- Provided Dependencies -->

--- a/fabric/fabric-core/src/main/java/io/fabric8/service/ChecksumPlaceholderResolver.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/ChecksumPlaceholderResolver.java
@@ -24,6 +24,7 @@ import io.fabric8.common.util.Closeables;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.security.InvalidParameterException;
 import java.util.Map;
 
 import org.apache.felix.scr.annotations.Activate;
@@ -62,7 +63,13 @@ public final class ChecksumPlaceholderResolver extends AbstractComponent impleme
 
     @Override
     public String resolve(FabricService fabricService, Map<String, Map<String, String>> configs, String pid, String key, String value) {
-        InputStream is = null;
+    	// The use of the mvel URL handler inside the checksum resolver
+    	// will produce an infinit loop and a stackOverflowError
+    	if(value.contains(":mvel:") || value.contains(":mvel\\:")){
+        	LOGGER.error("The checksum URL cannot contain mvel sub-URL");
+        	throw new InvalidParameterException("The checksum URL cannot contain mvel sub-URL");
+        }
+    	InputStream is = null;
         try {
             URL url = new URL(value.substring("checksum:".length()));
             is = url.openStream();

--- a/fabric/fabric-core/src/main/java/io/fabric8/service/MvelUrlHandler.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/MvelUrlHandler.java
@@ -1,0 +1,141 @@
+/**
+ *  Copyright 2005-2014 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+
+import io.fabric8.api.FabricService;
+import io.fabric8.api.RuntimeProperties;
+import io.fabric8.api.jcip.ThreadSafe;
+import io.fabric8.api.scr.Validatable;
+import io.fabric8.api.scr.ValidatingReference;
+import io.fabric8.api.scr.ValidationSupport;
+
+import org.mvel2.templates.CompiledTemplate;
+import org.mvel2.templates.TemplateCompiler;
+import org.mvel2.templates.TemplateRuntime;
+import org.osgi.service.url.AbstractURLStreamHandlerService;
+import org.osgi.service.url.URLStreamHandlerService;
+
+@ThreadSafe
+@Component(name = "io.fabric8.mvel.urlhandler", label = "Fabric8 MVEL URL Handler", immediate = true, metatype = false)
+@Service(URLStreamHandlerService.class)
+@Properties({
+        @Property(name = "url.handler.protocol", value = MvelUrlHandler.SCHEME)
+})
+public final class MvelUrlHandler extends AbstractURLStreamHandlerService implements Validatable {
+
+	protected static final String SCHEME = "mvel";
+    private static final String SYNTAX = SCHEME + ":<resource name>";
+
+    @Reference(referenceInterface = FabricService.class)
+    private final ValidatingReference<FabricService> fabricService = new ValidatingReference<FabricService>();
+    @Reference(referenceInterface = RuntimeProperties.class)
+    private final ValidatingReference<RuntimeProperties> runtimeProperties = new ValidatingReference<RuntimeProperties>();
+    
+    private final ValidationSupport active = new ValidationSupport();
+
+    @Activate
+    void activate() {
+    	active.setValid();
+    }
+
+    @Deactivate
+    void deactivate() {
+    	active.setInvalid();
+    }
+
+    @Override
+    public boolean isValid() {
+        return active.isValid();
+    }
+
+    @Override
+    public void assertValid() {
+        active.assertValid();
+    }
+
+    @Override
+    public URLConnection openConnection(URL url) throws IOException {
+        assertValid();
+        return new Connection(url);
+    }
+
+    private class Connection extends URLConnection {
+
+        public Connection(URL url) throws MalformedURLException {
+            super(url);
+            if (url.getPath() == null || url.getPath().trim().length() == 0) {
+                throw new MalformedURLException("Path can not be null or empty. Syntax: " + SYNTAX);
+            }
+            if ((url.getHost() != null && url.getHost().length() > 0) || url.getPort() != -1) {
+                throw new MalformedURLException("Unsupported host/port in " + SCHEME + " url");
+            }
+            if (url.getQuery() != null && url.getQuery().length() > 0) {
+                throw new MalformedURLException("Unsupported query in " + SCHEME + " url");
+            }
+        }
+
+        @Override
+        public void connect() throws IOException {
+            assertValid();
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+        	assertValid();
+        	String path = url.getPath();
+            URL url = new URL(path);
+            CompiledTemplate compiledTemplate = TemplateCompiler.compileTemplate(url.openStream());
+            Map<String, Object> data = new HashMap<String, Object>();
+            data.put("profile", fabricService.get().getCurrentContainer().getOverlayProfile());
+            data.put("runtime", runtimeProperties.get());
+            String content = TemplateRuntime.execute(compiledTemplate, data).toString();
+            return new ByteArrayInputStream(content.getBytes());
+        }
+    }
+
+    void bindFabricService(FabricService fabricService) {
+        this.fabricService.bind(fabricService);
+    }
+
+    void unbindFabricService(FabricService fabricService) {
+        this.fabricService.unbind(fabricService);
+    }
+    
+    void bindRuntimeProperties(RuntimeProperties service) {
+        this.runtimeProperties.bind(service);
+    }
+
+    void unbindRuntimeProperties(RuntimeProperties service) {
+        this.runtimeProperties.unbind(service);
+    }
+}

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/default.profile/jetty.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/default.profile/jetty.xml
@@ -36,11 +36,11 @@ DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
                 <Set name="host">
                     <Property name="jetty.host"/>
                 </Set>
-                <!-- We explicitly set port to 0 to avoid port conflicts, then a real port will be picked
-                     from org.ops4j.pax.web pid, which is PortService aware
+                <!-- The port value is synchronised with the ConfigAdmin Pax-Web port value
                 -->
                 <Set name="port">
-                    <Property name="jetty.port" default="0"/>
+                    <Property name="jetty.port" 
+                    	default="@{profile.getConfiguration('org.ops4j.pax.web').get('org.osgi.service.http.port')}"/>
                 </Set>
                 <Set name="maxIdleTime">300000</Set>
                 <Set name="Acceptors">2</Set>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/default.profile/org.ops4j.pax.web.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/default.profile/org.ops4j.pax.web.properties
@@ -16,5 +16,5 @@
 
 org.osgi.service.http.port=${port:8181,8282}
 javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
-org.ops4j.pax.web.config.url=profile:jetty.xml
+org.ops4j.pax.web.config.url=mvel:profile:jetty.xml
 org.ops4j.pax.web.config.checksum=${checksum:profile\:jetty.xml}

--- a/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
+++ b/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
@@ -192,6 +192,7 @@
         <bundle>mvn:io.fabric8/fabric-api/${project.version}</bundle>
         <feature version="${project.version}">fabric-git</feature>
         <feature version="${project.version}">fabric-zookeeper</feature>
+        <bundle dependency="true">mvn:org.mvel/mvel2/${mvel-version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jsch/${jsch-smx-version}</bundle>
         <bundle dependency="true">mvn:commons-collections/commons-collections/${commons-collections-version}</bundle>
         <bundle dependency="true">mvn:commons-beanutils/commons-beanutils/${commons-beanutils-version}</bundle>


### PR DESCRIPTION
For one of my use case, I need to be able to setup a specific jetty SSLConnector for my https connection. To do so, I need to create a specific jetty xml file with my connector and the port to which I want to use. THe problem is that pax-web also use a specific property to specify the port number.
One of the tweak that was done in fabric8 was to use a 0 port value so that pax-web overwrite the conf with the good port value. This works for standard http connection but as far as the https connection is concerned this does not work.

After discussion with @iocanel it was decided to create a generic mvel URL handler to do it... and more if needed :-) .

Best,
Jerome
