### PR TITLE
Adding RuleBaseReader for rules defined in JSON format.

### DIFF
--- a/gateway/gateway-model/pom.xml
+++ b/gateway/gateway-model/pom.xml
@@ -51,6 +51,10 @@
       <artifactId>common-util</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/gateway/gateway-model/src/main/java/io/fabric8/gateway/support/JsonRuleBaseReader.java
+++ b/gateway/gateway-model/src/main/java/io/fabric8/gateway/support/JsonRuleBaseReader.java
@@ -1,0 +1,99 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.support;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.gateway.model.HttpProxyRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class with methods to read {@link HttpProxyRule}s in JSON format.
+ */
+public final class JsonRuleBaseReader {
+
+    private static final ObjectMapper OM = new ObjectMapper();
+    private static final Logger LOG = LoggerFactory.getLogger(JsonRuleBaseReader.class);
+
+    private JsonRuleBaseReader() {
+    }
+
+    /**
+     * Will try to parse the {@link InputStream} which is expected to be in the following
+     * JSON format:
+     * <pre>
+     * { "rulebase" : [
+     *    { "rule": "/foo/{path}", "to": "https://foo.com/cheese/{path}"},
+     *    { "rule": "/customers/{id}/address/{addressId}", "to": "http://another.com/addresses/{addressId}/customer/{id}"}
+     *  ]
+     * }
+     * </pre>
+     *
+     * <strong>Note that the passed-in {@link InputStream} will be closed by this method</strong>. This
+     * is a little unusual as normally the closing is the responsibility of the party that created the
+     * InputStream, but in this case we decided handling this is more user friendly.
+     *
+     * @param in the {@link InputStream} stream to read.
+     * @return {@code Map} where the key maps to the 'rule' in the JSON, and the value maps to 'to'.
+     */
+    public static Map<String, HttpProxyRule> parseJson(InputStream in) {
+        chechNotNull(in);
+        HashMap<String, HttpProxyRule> map = new HashMap<String, HttpProxyRule>();
+        try {
+            for (JsonNode node : getRuleBase(OM.readTree(in))) {
+                String rule = node.get("rule").asText();
+                HttpProxyRule httpProxyRule = new HttpProxyRule(rule);
+                httpProxyRule.to(node.get("to").asText());
+                map.put(rule, httpProxyRule);
+            }
+            return map;
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        } finally {
+            safeClose(in);
+        }
+    }
+
+    private static JsonNode getRuleBase(JsonNode json) {
+        JsonNode rules = json.get("rulebase");
+        if (rules == null) {
+            throw new IllegalStateException("Could not locate the 'rulebase' property");
+        }
+        return rules;
+    }
+
+    private static void safeClose(InputStream in) {
+        try {
+            in.close();
+        } catch (IOException e) {
+            LOG.warn("Exception while trying to close JSON input stream", e);
+        }
+    }
+
+    private static void chechNotNull(InputStream in) {
+        if (in == null) {
+            throw new IllegalArgumentException("InputStream must not be null");
+        }
+    }
+}

--- a/gateway/gateway-model/src/test/java/io/fabric8/gateway/support/JsonRuleBaseReaderTest.java
+++ b/gateway/gateway-model/src/test/java/io/fabric8/gateway/support/JsonRuleBaseReaderTest.java
@@ -1,0 +1,110 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.support;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.fabric8.gateway.model.HttpProxyRule;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JsonRuleBaseReaderTest {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    @Test (expected = IllegalArgumentException.class)
+    public void shouldThrowIfResourceIsNotFound() throws IOException {
+        JsonRuleBaseReader.parseJson(null);
+    }
+
+    @Test (expected = IllegalStateException.class)
+    public void parseMissingRulebaseProperty() throws Exception {
+        JsonRuleBaseReader.parseJson(JsonRuleBaseBuilder.withRootElementName("badElementName").inputStream());
+    }
+
+    @Test
+    public void parseNoRules() throws Exception {
+        assertTrue(JsonRuleBaseReader.parseJson(JsonRuleBaseBuilder.newRuleBase().inputStream()).isEmpty());
+    }
+
+    @Test
+    public void parseJson() throws Exception {
+        final InputStream in = JsonRuleBaseBuilder.newRuleBase()
+                .rule("/foo/{path}", "https://foo.com/cheese/{path}")
+                .rule("/cust/{id}/address/{addressId}", "http://at.com/addresses/{addressId}/cust/id}")
+                .inputStream();
+        Map<String, HttpProxyRule> rules = JsonRuleBaseReader.parseJson(in);
+        assertEquals("https://foo.com/cheese/{path}", asString(rules.get("/foo/{path}")));
+        assertEquals("http://at.com/addresses/{addressId}/cust/id}", asString(rules.get("/cust/{id}/address/{addressId}")));
+        assertClosed(in);
+    }
+
+    private static void assertClosed(InputStream in) {
+        try {
+            in.read();
+            if (!(in instanceof ByteArrayInputStream)) {
+                Assert.fail("InputStream should have been closed.");
+            }
+        } catch(IOException ignored) {
+        }
+    }
+
+    private static String asString(HttpProxyRule rule) {
+        return rule.getDestinationUriTemplates().iterator().next().getUriTemplate();
+    }
+
+    private static class JsonRuleBaseBuilder {
+
+        private final ObjectNode json;
+        private final ArrayNode rules;
+
+        private JsonRuleBaseBuilder(String rootElementName) {
+            json = JsonNodeFactory.instance.objectNode();
+            rules = JsonNodeFactory.instance.arrayNode();
+            json.put(rootElementName, rules);
+        }
+
+        public static JsonRuleBaseBuilder withRootElementName(String name) {
+            return new JsonRuleBaseBuilder(name);
+        }
+
+        public static JsonRuleBaseBuilder newRuleBase() {
+            return new JsonRuleBaseBuilder("rulebase");
+        }
+
+        public JsonRuleBaseBuilder rule(String rule, String to) {
+            rules.add(JsonNodeFactory.instance.objectNode().put("rule", rule).put("to", to));
+            return this;
+        }
+
+        public InputStream inputStream() {
+            return new ByteArrayInputStream(json.toString().getBytes(UTF_8));
+        }
+
+    }
+}


### PR DESCRIPTION
Motivation:
The ProxyServlet class provides the abstract loadRuleBase method in
which concrete implmentation can define the proxy rules. Currently
subclasses can use the Java DSL, or whatever way they chose to read the
rules and make them available. This pull request provides support for
defining rules in JSON format.

Modifications:
- Added a dependency to com.fasterxml.jackson.core:jackson-databind.
- Added RuleBaseReader.
