### PR TITLE
Removing hop-by-hop headers for ProxyServlet

### DIFF
--- a/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/ProxyServlet.java
+++ b/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/ProxyServlet.java
@@ -2,6 +2,7 @@ package io.fabric8.gateway.servlet;
 
 import io.fabric8.common.util.IOHelpers;
 import io.fabric8.gateway.model.HttpProxyRuleBase;
+import io.fabric8.gateway.servlet.support.ProxySupport;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
@@ -340,7 +341,9 @@ public abstract class ProxyServlet extends HttpServlet {
         // Pass response headers back to the client
         Header[] headerArrayResponse = httpMethodProxyRequest.getResponseHeaders();
         for (Header header : headerArrayResponse) {
-            httpServletResponse.setHeader(header.getName(), header.getValue());
+            if (!ProxySupport.isHopByHopHeader(header.getName())) {
+                httpServletResponse.setHeader(header.getName(), header.getValue());
+            }
         }
 
         // check if we got data, that is either the Content-Length > 0

--- a/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/support/ProxySupport.java
+++ b/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/support/ProxySupport.java
@@ -1,0 +1,45 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.servlet.support;
+
+/**
+ * Utility methods for Proxy related operations.
+ */
+public final class ProxySupport {
+
+    private ProxySupport() {
+    }
+
+    /**
+     * Checks if the passed-in header is a hop-by-hop header as defined by
+     * <a href="http://tools.ietf.org/html/rfc2616#section-13.5.1">RFC-2616 Section 13.5.1</a>.
+     *
+     * @param header the header name to check.
+     * @return {@code true} if the header is a hop-by-hop header, false otherwise.
+     */
+    public static boolean isHopByHopHeader(final String header){
+        return  header.equalsIgnoreCase("Connection") ||
+                header.equalsIgnoreCase("Keep-Alive") ||
+                header.equalsIgnoreCase("Proxy-Authentication") ||
+                header.equalsIgnoreCase("Proxy-Authorization") ||
+                header.equalsIgnoreCase("TE") ||
+                header.equalsIgnoreCase("Trailers") ||
+                header.equalsIgnoreCase("Transfer-Encoding") ||
+                header.equalsIgnoreCase("Upgrade");
+    }
+}

--- a/gateway/gateway-servlet/src/test/java/io/fabric8/gateway/servlet/support/ProxySupportTest.java
+++ b/gateway/gateway-servlet/src/test/java/io/fabric8/gateway/servlet/support/ProxySupportTest.java
@@ -1,0 +1,74 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.servlet.support;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ProxySupportTest {
+
+    @Test
+    public void transferEncodingIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("Transfer-Encoding"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("transfer-encoding"), is(true));
+    }
+
+    @Test
+    public void connectionIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("Connection"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("connection"), is(true));
+    }
+
+    @Test
+    public void keepAliveIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("Keep-Alive"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("keep-alive"), is(true));
+    }
+
+    @Test
+    public void proxyAuthenticationIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("Proxy-Authentication"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("proxy-authentication"), is(true));
+    }
+
+    @Test
+    public void proxyAutherizationIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("Proxy-Authorization"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("proxy-authorization"), is(true));
+    }
+
+    @Test
+    public void teIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("TE"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("te"), is(true));
+    }
+
+    @Test
+    public void trailersIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("Trailers"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("trailers"), is(true));
+    }
+
+    @Test
+    public void upgradeIsHopByHop() throws Exception {
+        assertThat(ProxySupport.isHopByHopHeader("Upgrade"), is(true));
+        assertThat(ProxySupport.isHopByHopHeader("upgrade"), is(true));
+    }
+}


### PR DESCRIPTION
Motivation:
RFC 2616 specifies a number of headers that are hop-by-hop and proxy
server are required to remove them [1].

The issue I ran into was when the ProxyServlet was deployed on EAP 6.3
and the proxy server set the response header 'Transfer-Encoding: chunked'
which cause the client to fail as the response from the proxy was not
chunked.

Modifications:
Added a check of header names before adding them to them to the
HttpServletRequest.

[1] http://tools.ietf.org/html/rfc2616#section-13.5.1
