### PR TITLE
MappingRuleResolver is dependant on HashMap's values ordering.

### DIFF
--- a/gateway/gateway-model/src/main/java/io/fabric8/gateway/support/UriTemplate.java
+++ b/gateway/gateway-model/src/main/java/io/fabric8/gateway/support/UriTemplate.java
@@ -46,27 +46,33 @@ public class UriTemplate {
 
     public MappingResult matches(String[] requestUriPaths, HttpProxyRule proxyRule) {
         int actualLength = requestUriPaths.length;
+        int processedPaths = 0;
+        boolean joinedPath = false;
         Map<String, String> parameterNameValues = new HashMap<String, String>();
-        for (int i = 0, lastIndex = paths.length - 1; i <= lastIndex; i++) {
+        for (int lastIndex = paths.length - 1; processedPaths <= lastIndex; processedPaths++) {
             String actualSegment = null;
-            if (i < actualLength) {
-                actualSegment = requestUriPaths[i];
+            if (processedPaths < actualLength) {
+                actualSegment = requestUriPaths[processedPaths];
             }
             if (actualSegment == null) {
                 return null;
             }
-            String parameterName = getWildcardParameterName(i);
+            String parameterName = getWildcardParameterName(processedPaths);
             if (parameterName != null) {
-                if (i == lastIndex) {
-                    actualSegment = joinPath(i, requestUriPaths);
+                if (processedPaths == lastIndex) {
+                    actualSegment = joinPath(processedPaths, requestUriPaths);
+                    joinedPath = true;
                 }
                 parameterNameValues.put(parameterName, actualSegment);
             } else {
-                String pathSegment = paths[i];
+                String pathSegment = paths[processedPaths];
                 if (pathSegment == null || !actualSegment.equals(pathSegment)) {
                     return null;
                 }
             }
+        }
+        if (!joinedPath && processedPaths < actualLength) {
+            return null;
         }
         return new MappingResult(parameterNameValues, requestUriPaths, proxyRule);
     }

--- a/gateway/gateway-model/src/test/java/io/fabric8/gateway/support/MappingRuleResolverTest.java
+++ b/gateway/gateway-model/src/test/java/io/fabric8/gateway/support/MappingRuleResolverTest.java
@@ -40,12 +40,16 @@ public class MappingRuleResolverTest extends MappingRuleTestSupport {
 
     @Test
     public void testResolver() throws Exception {
+        assertRuleMatch("/members", "http://foo.com/rest/members");
+        assertRuleMatch("/members/10001", "http://foo.com/rest/members/10001");
         assertRuleMatch("/foo/something/else", "http://foo.com/cheese/something/else");
         assertRuleMatch("/customers/c123/address/abc", "http://another.com/addresses/abc/customerThingy/c123");
     }
 
     @Override
     protected void loadMappingRules(HttpProxyRuleBase ruleBase) {
+        ruleBase.rule("/members").to("http://foo.com/rest/members");
+        ruleBase.rule("/members/{id}").to("http://foo.com/rest/members/{id}");
         ruleBase.rule("/foo/{path}").to("http://foo.com/cheese/{path}");
         ruleBase.rule("/customers/{customerId}/address/{addressId}").to("http://another.com/addresses/{addressId}/customerThingy/{customerId}");
     }


### PR DESCRIPTION
Motivation:
When testing the ProxyServlet I noticed that it behaves differently when
running Java 7 vs Java 8.

If one defines the following rules:
/members -> members
/members/{id} -> members/{id}

MappingRuleResolver calls mappingRules.getMappingRules.values() which
returns the following:
Java 7                  Java 8
[0] /members            [0] /members/{id}
[1] /members/{id}       [1] /members

UriTemplate will match /members for Java 7 even if the actual request
path is /members/10002 for example.

Modifications:
I've updated UriTemplate's matches method to try to take into account
that there might be additional request paths to consider and if so
return null and allow the caller to try matching again using the next
rule (if any).
