### PR TITLE
Fixed race condition in ProcessUtils#killProcess method

### DIFF
--- a/process/process-manager/src/main/java/io/fabric8/process/manager/support/ProcessUtils.java
+++ b/process/process-manager/src/main/java/io/fabric8/process/manager/support/ProcessUtils.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import static java.lang.String.format;
+
 public class ProcessUtils {
     private static final transient Logger LOGGER = LoggerFactory.getLogger(ProcessUtils.class);
 
@@ -120,7 +122,12 @@ public class ProcessUtils {
                     commands +
                     ": " + e, e);
         }
-        return process != null ? process.exitValue() : 1;
+        try {
+            return process != null ? process.waitFor() : 1;
+        } catch (InterruptedException e) {
+            String message = format("Interrupted while waiting for 'kill %d ' command to finish", pid);
+            throw new RuntimeException(message, e);
+        }
     }
 
     protected static void parseProcesses(InputStream inputStream, List<Long> answer, String message) throws Exception {


### PR DESCRIPTION
Hi,

`ProcessUtils#killProcess` execution often ends up in `IllegalThreadStateException: process hasn't exited` exception being thrown. This happens because kill command is usually slower than Java here and then `process.exitValue()` is called before the kill command finishes execution.

We should call blocking `process.waitFor()` method here instead so kill process can finish and join our Java thread.

We could consider executing kill command via executor framework and use futures here, but I'm not sure if it is worth such optimization, as kill command is pretty fast.

Cheers.
