### PR TITLE
Resolved FABRIC-624 - fixed process manager ProcessControllerTest

### DIFF
--- a/process/process-test/pom.xml
+++ b/process/process-test/pom.xml
@@ -66,4 +66,21 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/process/process-test/src/main/java/io/fabric8/process/test/AbstractProcessTest.java
+++ b/process/process-test/src/main/java/io/fabric8/process/test/AbstractProcessTest.java
@@ -97,9 +97,9 @@ public abstract class AbstractProcessTest extends Assert {
         processManagerService = new ProcessManagerService(new File("target", randomUUID().toString()));
     }
 
-    protected static void startProcess(final ProcessController processController) throws Exception {
+    protected static int startProcess(final ProcessController processController) throws Exception {
         try {
-            processController.start();
+            return processController.start();
         } finally {
             getRuntime().addShutdownHook(new Thread() {
                 @Override
@@ -110,12 +110,13 @@ public abstract class AbstractProcessTest extends Assert {
         }
     }
 
-    protected static void stopProcess(ProcessController processController) {
+    protected static int stopProcess(ProcessController processController) {
         try {
             if (processController != null) {
-                processController.stop();
+                return processController.stop();
             } else {
                 System.out.println("Process controller has not been initialized - skipping stop command.");
+                return -1;
             }
         } catch (IllegalThreadStateException e) {
             System.out.println(format("There is no need to kill the process %s. Process already stopped.", processController));
@@ -123,6 +124,7 @@ public abstract class AbstractProcessTest extends Assert {
             System.out.println("Problem occurred while stopping the process " + processController);
             e.printStackTrace();
         }
+        return -1;
     }
 
     protected static void waitForRestResource(final String uri) {

--- a/process/process-test/src/test/java/io/fabric8/process/manager/ProcessControllerTest.java
+++ b/process/process-test/src/test/java/io/fabric8/process/manager/ProcessControllerTest.java
@@ -17,33 +17,17 @@ package io.fabric8.process.manager;
 
 import io.fabric8.api.FabricConstants;
 import io.fabric8.common.util.Strings;
-import io.fabric8.process.manager.service.ProcessManagerService;
-import org.junit.Before;
+import io.fabric8.process.test.AbstractProcessTest;
 import org.junit.Test;
 import org.ops4j.pax.url.mvn.Handler;
-
-import javax.management.MalformedObjectNameException;
 
 import java.io.File;
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-
-public class ProcessControllerTest {
-    protected ProcessManagerService processManager;
-
-    @Before
-    public void setUp() throws MalformedObjectNameException {
-        processManager = new ProcessManagerService(new File("target/processes"));
-    }
+public class ProcessControllerTest extends AbstractProcessTest {
 
     @Test
     public void startStopCamelSample() throws Exception {
-        System.setProperty("java.protocol.handler.pkgs", "org.ops4j.pax.url.mvn");
-        processManager.init();
-
         InstallTask postInstall = null;
 
         String version = FabricConstants.FABRIC_VERSION;
@@ -53,7 +37,7 @@ public class ProcessControllerTest {
                                                .url(new URL(null, "mvn:io.fabric8.samples/process-sample-camel-spring/" + version + "/tar.gz", new Handler()))
                                                .build();
 
-        Installation install = processManager.install(options, postInstall);
+        Installation install = processManagerService.install(options, postInstall);
 
         String id = install.getId();
         assertTrue("ID should not be blank " + id, Strings.isNotBlank(id));
@@ -65,12 +49,12 @@ public class ProcessControllerTest {
         // now lets start the process
         ProcessController controller = install.getController();
 
-        int rc = controller.start();
+        int rc = startProcess(controller);
         assertEquals("Return code", 0, rc);
 
         Thread.sleep(2000);
 
-        rc = controller.stop();
+        rc = stopProcess(controller);
         assertEquals("Return code", 0, rc);
     }
 }


### PR DESCRIPTION
Hi,

Last night I've fixed race condition [1] in `ProcessUtils#killProcess` that basically resolved problems with `ProcessControllerTest`. I also applied my process testing API [2] to that test, to make it smaller and to be sure that spawned process is properly killed (i.e. not leaking on build machine).

Cheers.

[1] https://github.com/fabric8io/fabric8/pull/1455
[2] https://github.com/fabric8io/fabric8/pull/1453
