### PR TITLE
Fixed NPE in JoinAction

### DIFF
--- a/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/JoinAction.java
+++ b/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/JoinAction.java
@@ -116,7 +116,13 @@ final class JoinAction extends AbstractAction {
         }
 
         zookeeperPassword = zookeeperPassword != null ? zookeeperPassword : ShellUtils.retrieveFabricZookeeperPassword(session);
-        String encodedPassword = PasswordEncoder.encode(zookeeperPassword);
+        String encodedPassword = null;
+        if(zookeeperPassword != null) {
+            log.debug("Encoding ZooKeeper password.");
+            encodedPassword = PasswordEncoder.encode(zookeeperPassword);
+        } else {
+            log.debug("ZooKeeper password not specified. Password encoding skipped.");
+        }
         runtimeProperties.setProperty(ZkDefs.MINIMUM_PORT, String.valueOf(minimumPort));
         runtimeProperties.setProperty(ZkDefs.MAXIMUM_PORT, String.valueOf(maximumPort));
 


### PR DESCRIPTION
We should not try to encode `null` password. Now we throw `NullPointerException` if `--zookeeper-password` option is not added to the `join` command.

Null password indicates that `password ... will be generated if not given`, so we should just skip the encoding for `null` passwords.

Added also some extra logging.
