### PR TITLE
[Process manager] Folks can now easily enable JVM debug on managed process.

### DIFF
--- a/process/process-launcher/src/main/distro/bin/launcher
+++ b/process/process-launcher/src/main/distro/bin/launcher
@@ -13,7 +13,19 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 #  implied.  See the License for the specific language governing
 #  permissions and limitations under the License.
-#
+
+### Helper functions
+
+jvmDebug() {
+  if [ "$FABRIC8_JVM_DEBUG" == 'TRUE' ]; then
+    echo -n '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005'
+  else
+    echo -n
+  fi
+}
+
+### Helper functions ends
+
 
 APP_USER=""
 SERVICE="process"
@@ -122,9 +134,9 @@ start() {
   fi
 
   if [ -z "$MAIN_CLASS" ]; then
-    RUN_COMMAND="${JVM_EXEC} ${JAVA_AGENT} ${JVM_ARGS} -classpath ${CLASSPATH} -jar ${MAIN_JAR} ${APP_ARGS}"
+    RUN_COMMAND="${JVM_EXEC} `jvmDebug` ${JAVA_AGENT} ${JVM_ARGS} -classpath ${CLASSPATH} -jar ${MAIN_JAR} ${APP_ARGS}"
   else
-    RUN_COMMAND="${JVM_EXEC} ${JAVA_AGENT} ${JVM_ARGS} -classpath ${CLASSPATH} ${MAIN_CLASS} ${APP_ARGS}"
+    RUN_COMMAND="${JVM_EXEC} `jvmDebug` ${JAVA_AGENT} ${JVM_ARGS} -classpath ${CLASSPATH} ${MAIN_CLASS} ${APP_ARGS}"
   fi
 
   echo "Running $RUN_COMMAND"


### PR DESCRIPTION
Hi,

Yet another pull request from "making Fabric8 a devops heaven" series. If something goes wrong with the managed process and folks need to debug it with IDE, all we need to do is to set FABRIC8_JVM_DEBUG environmental variable to TRUE:

```
 FABRIC8_JVM_DEBUG=TRUE bin/launcher start
```

And connect to the managed process using JDWP on port 5005 (default IntelliJ's port for debugger).

We could add some options to customize `port` and `suspend` parts of the JDWP agent in the future, but default `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005` should be sufficient for the majority of the cases for a while.

Cheers.
