### PR TITLE
[Java container] Added jarUrl option to JavaContainerConfig

### DIFF
--- a/fabric/fabric-process-container/src/main/java/io/fabric8/container/process/JavaContainerConfig.java
+++ b/fabric/fabric-process-container/src/main/java/io/fabric8/container/process/JavaContainerConfig.java
@@ -32,6 +32,11 @@ import static io.fabric8.service.child.JavaContainerEnvironmentVariables.FABRIC8
  */
 @Component(name = "io.fabric8.container.java", label = "Fabric8 Java Child Container Configuration", immediate = false, metatype = true)
 public class JavaContainerConfig {
+
+    @Property(label = "Jar URL", cardinality = 1,
+            description = "The URL (usually using maven coordinates) for the jar to install.")
+    private String jarUrl;
+
     @Property(label = "Java main class",
             description = "The name of the Java class which contains a static main(String[] args) function.")
     private String mainClass;
@@ -69,6 +74,14 @@ public class JavaContainerConfig {
         }
     }
 
+    public String getJarUrl() {
+        return jarUrl;
+    }
+
+    public void setJarUrl(String jarUrl) {
+        this.jarUrl = jarUrl;
+    }
+
     public String getMainClass() {
         return mainClass;
     }
@@ -100,4 +113,5 @@ public class JavaContainerConfig {
     public void setJvmArguments(String jvmArguments) {
         this.jvmArguments = jvmArguments;
     }
+
 }

--- a/fabric/fabric-process-container/src/main/java/io/fabric8/container/process/ProcessManagerController.java
+++ b/fabric/fabric-process-container/src/main/java/io/fabric8/container/process/ProcessManagerController.java
@@ -342,6 +342,9 @@ public class ProcessManagerController implements ChildContainerController {
         setProvisionList(container, javaArtifacts);
 
         InstallOptions.InstallOptionsBuilder builder = InstallOptions.builder();
+        if(javaConfig.getJarUrl() != null) {
+            builder.url(javaConfig.getJarUrl());
+        }
         builder.container(container);
         builder.jarFiles(javaArtifacts);
         builder.id(options.getName());


### PR DESCRIPTION
Added `jarUrl` option to `JavaContainerConfig`, so folks can install jar into Java Container the same way they install jars via `install-jar` command. For example to map the following command...

```
process:install-jar -m com.my.Main my.group.id my-artifact 1.0
```

...to Java Container managed jar, we now can specify the following properties in `io.fabric8.container.java.properties`:

```
mainClass=com.my.Main
jarUrl=mvn:my.group.id/my-artifact/1.0
```
