### PR TITLE
[Java container] $FABRIC8_JVM_ARGS overrides etc/jvm.config

### DIFF
--- a/process/process-launcher/src/main/distro/bin/launcher
+++ b/process/process-launcher/src/main/distro/bin/launcher
@@ -24,6 +24,14 @@ jvmDebug() {
   fi
 }
 
+jvmArgs() {
+  if [ -z "$FABRIC8_JVM_ARGS" ]; then
+    cat ${APP_BASE}/etc/jvm.config
+  else
+    echo "$FABRIC8_JVM_ARGS"
+  fi
+}
+
 ### Helper functions ends
 
 
@@ -79,7 +87,7 @@ CLASSPATH="$CLASSPATH:$APP_BASE/classes"
 
 JVM_EXEC="java"
 JAVA_AGENT="$FABRIC8_JAVA_AGENT"
-JVM_ARGS=`cat ${APP_BASE}/etc/jvm.config`" $FABRIC8_JVM_ARGS"
+JVM_ARGS=`jvmArgs`
 APP_ARGS="$FABRIC8_MAIN_ARGS"
 MAIN_JAR="$APP_BASE/lib/main.jar"
 MAIN_CLASS="$FABRIC8_JAVA_MAIN"


### PR DESCRIPTION
We should store the values passed to the Fabric when creating Java Container (JVM options, main class, application arguments). Otherwise we won't be able to execute managed processes via `bin/launcher start`, because these settings won't be remembered by the process itself.

We can't force users to execute processes only via Fabric - that would be a devops hell. If Fabric is down for some reasons, folks still should be able to manage their processes manually. That would be production-saver.

I changed launcher slightly, so it tries to read `$FABRIC8_JVM_ARGS` environmental variable and fallback to the `etc/jvm.config` if the former is empty. This way Fabric can overrides value cached in the process directory.

BTW We should consider using process IO API (#1354) to update files like `etc/jvm.config` when the values in the `io.fabric8.container.java` PID changed.
