### PR TITLE
#1531: MQ create should set the child parent profile to mq-client-base, instead of being null. Otherwise creating client containers will fail.

### DIFF
--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/MQCreateAction.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/MQCreateAction.java
@@ -52,7 +52,7 @@ public class MQCreateAction extends AbstractAction {
     @Option(name = "--client-profile", description = "The profile name for clients to use to connect to the broker group. Defaults to 'mq-client-$GROUP'")
     protected String clientProfile;
 
-    @Option(name = "--client-parent-profile", description = "The parent profile used for the client-profile for clients connecting to the broker group. Defaults to 'default'")
+    @Option(name = "--client-parent-profile", description = "The parent profile used for the client-profile for clients connecting to the broker group. Defaults to 'mq-client-base'")
     protected String clientParentProfile;
 
     @Option(name = "--property", aliases = {"-D"}, description = "Additional properties to define in the profile", multiValued = true)

--- a/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/MQManager.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/api/jmx/MQManager.java
@@ -478,7 +478,11 @@ public class MQManager implements MQManagerMXBean {
 
         String clientProfile = dto.clientProfile();
         if (Strings.isNotBlank(clientProfile)) {
-            mqService.createOrUpdateMQClientProfile(version, clientProfile, group, dto.getClientParentProfile());
+            String clientParentProfile = dto.getClientParentProfile();
+            if (Strings.isNullOrBlank(clientParentProfile)) {
+                clientParentProfile = "mq-client-base";
+            }
+            mqService.createOrUpdateMQClientProfile(version, clientProfile, group, clientParentProfile);
         }
         return profile;
     }

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/client/default.profile/ReadMe.md
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/client/default.profile/ReadMe.md
@@ -1,1 +1,1 @@
-A profile which provides an ActiveMQConnectionFactory (JMS client) for connecting via JMS or camel to an A-MQ broker running in default group
+A profile which provides an ActiveMQConnectionFactory (JMS client) for connecting via JMS or Camel to an A-MQ broker running in default group

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/client/local.profile/ReadMe.md
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/client/local.profile/ReadMe.md
@@ -1,3 +1,3 @@
-A profile which provides an ActiveMQConnectionFactory (JMS client) for connecting via JMS or camel to an A-MQ broker running on localhost.
+A profile which provides an ActiveMQConnectionFactory (JMS client) for connecting via JMS or Camel to an A-MQ broker running on localhost.
 
 Typically this is used for working with local brokers on the same machine; or for when the [gateway profile](/fabric/profiles/gateway/default.profile) is used to proxy to the actual locations of the brokers.


### PR DESCRIPTION
...instead of being null. Otherwise creating client containers will fail.
