### PR TITLE
Fixes #1631 Adding a non binding ProtocolSocketFactory impl

### DIFF
--- a/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/ProxyServlet.java
+++ b/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/ProxyServlet.java
@@ -18,6 +18,7 @@ package io.fabric8.gateway.servlet;
 import io.fabric8.common.util.IOHelpers;
 import io.fabric8.gateway.model.HttpProxyRule;
 import io.fabric8.gateway.model.HttpProxyRuleBase;
+import io.fabric8.gateway.servlet.support.NonBindingSocketFactory;
 import io.fabric8.gateway.servlet.support.ProxySupport;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
@@ -41,6 +42,7 @@ import org.apache.commons.httpclient.methods.multipart.FilePart;
 import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
 import org.apache.commons.httpclient.methods.multipart.Part;
 import org.apache.commons.httpclient.methods.multipart.StringPart;
+import org.apache.commons.httpclient.protocol.Protocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +114,8 @@ public abstract class ProxyServlet extends HttpServlet {
         HttpProxyRuleBase ruleBase = new HttpProxyRuleBase();
         loadRuleBase(config, ruleBase);
         resolver.setMappingRules(ruleBase);
+        Protocol.registerProtocol("http", new Protocol("http", new NonBindingSocketFactory(), 80));
+        Protocol.registerProtocol("https", new Protocol("https", new NonBindingSocketFactory(), 443));
     }
 
     /**

--- a/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/support/NonBindingSocketFactory.java
+++ b/gateway/gateway-servlet/src/main/java/io/fabric8/gateway/servlet/support/NonBindingSocketFactory.java
@@ -1,0 +1,67 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.servlet.support;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import org.apache.commons.httpclient.HttpConnection;
+import org.apache.commons.httpclient.params.HttpConnectionParams;
+import org.apache.commons.httpclient.protocol.DefaultProtocolSocketFactory;
+import org.apache.commons.httpclient.protocol.ProtocolSocketFactory;
+
+/**
+ * A @{link ProtocolSocketFactory} implementation that does not bind a socket.
+ * <p>
+ *
+ * The reason for this {@link ProtocolSocketFactory} implementation is that for ProxyServlet we don't need to
+ * bind to a local address and port. This binding can cause issue in PaaS environments where restrictions apply.
+ * <p>
+ *
+ * When {@link HttpConnection#open()} calls
+ * {@link ProtocolSocketFactory#createSocket(String, int, InetAddress, int, HttpConnectionParams)}
+ * which by default will use {@link DefaultProtocolSocketFactory#createSocket(String, int, InetAddress, int, HttpConnectionParams)}.
+ * The method that will be invoke is {@link DefaultProtocolSocketFactory#createSocket(String, int, InetAddress, int, HttpConnectionParams)}
+ * which will call {@code return new Socket(host, port, localAddress, localPort);}.
+ * The {@link Socket#Socket(InetAddress, int, InetAddress, int)} constructor will create a new Socket and connect to the
+ * remote address and port (the first two arguments). It will also bind() to the local address and port. This is
+ * the part that can cause issue in PaaS environment where there are restrictions.
+ *
+ */
+public class NonBindingSocketFactory implements ProtocolSocketFactory {
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localAddress, int localPort) throws IOException {
+        return createNonBindingSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localAddress, int localPort, HttpConnectionParams params) throws IOException {
+        return createNonBindingSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return createNonBindingSocket(host, port);
+    }
+
+    private static Socket createNonBindingSocket(String host, int port) throws IOException {
+        return new Socket(host, port);
+    }
+
+}


### PR DESCRIPTION
Motivation:
The reason for this ProtocolSocketFactory implementation is
that for ProxyServlet we don't need to bind to a local address and port.
This binding can cause issue in PaaS environments where restrictions apply.

When HttpConnection's open method calls ProtocolSocketFactory's
 createSocket(String, int, InetAddress, int, HttpConnectionParams)
which by default will use DefaultProtocolSocketFactory's
 createSocket(String, int, InetAddress, int, HttpConnectionParams).
The method that will be invoked will be DefaultProtocolSocketFactory's
 createSocket(String, int, InetAddress, int)
which will call
  return new Socket(host, port, localAddress, localPort);
The above constructor will create a new Socket and connect to the
remote address and port (the first two arguments). It will also
bind() to the local address and port. This is the part that can
cause issue in PaaS environment where there are restrictions.

Modifications:
Provide a NonBindingSocketFactory that ignores the local address and
port avoiding binding to a local address.

Result:
The ProxyServlet is usable in PaaS environments without additional
configuration required by users.
