### PR TITLE
made a workaround for the scala versions for swagger

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
+++ b/fabric/fabric8-karaf/src/main/resources/fabric-features.xml
@@ -658,7 +658,7 @@
 
     <feature name="swagger" version="${project.version}" resolver="(obr)">
         <feature version="${cxf-version-range}">cxf-specs</feature>
-        <bundle dependency='true'>mvn:org.scala-lang/scala-library/${scala-library-version}</bundle>
+        <bundle dependency='true'>mvn:org.scala-lang/scala-library/${swagger-scala-version}</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javassist/3.12.1.GA_3</bundle>
         <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jackson-module-scala/${jackson-module-scala-version}</bundle>
         <bundle>mvn:javax.validation/validation-api/${validation-api-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,7 @@
         <sshd-version>0.9.0</sshd-version>
         <sshj.version>0.8.1</sshj.version>
         <swagger-version>1.3.2_1</swagger-version>
+        <swagger-scala-version>2.10.2</swagger-scala-version>
         <tinybundles-version>1.0.0</tinybundles-version>
         <tomcat-version>7.0.53</tomcat-version>
         <tomee-version>1.6.0.2</tomee-version>


### PR DESCRIPTION
fixes #1737
however, needs review. can we upgrade the swagger bundles to use newer scala? or maybe I missed something and 2.11 is usable? please verify when you get a sec. otherwise rest profile from the quick starts is unusable in current state
