### PR TITLE
HDFS: initial working example + additions and dirty hacks to Fabric8 code to support recursive properties replacement. Added a couple of TODOs

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/cassandra.profile/controller.json
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/cassandra.profile/controller.json
@@ -2,3 +2,4 @@
     "startCommand": "bin/cassandra -p cassandra.pid",
     "pidFile": "cassandra.pid"
 }
+h

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/ReadMe.md
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/ReadMe.md
@@ -1,0 +1,6 @@
+## HDFS
+
+This profile lets you create an Hadoop File System 2.2 containers on your network with the role of DataNode.
+
+Since the profile has to download ~80MB from the internet that it cannot cache, be aware that each installation might take a while.
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/controller.json
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/controller.json
@@ -1,0 +1,7 @@
+{
+    "startCommand": " sh -c \" exec bin/hdfs --config $HADOOP_INSTALL/etc/hadoop datanode & 2>&1 ; echo $! > datanode.pid  \"  ",
+    "pidFile": "datanode.pid",
+    "installCommands": [
+        "mkdir -p $HADOOP_INSTALL/mydata/hdfs/namenode  $HADOOP_INSTALL/mydata/hdfs/datanode"
+    ]
+}

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.container.process.overlay.resources.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.container.process.overlay.resources.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+# specify the name inside the process distribution as the key and the value is the URL to download the file
+
+jolokia-agent.jar = mvn:org.jolokia/jolokia-jvm/1.2.1/jar/agent

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.container.process.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.container.process.properties
@@ -1,0 +1,32 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+processName = HDFS.datanode
+url = http://www.eu.apache.org/dist/hadoop/common/stable/hadoop-2.2.0.tar.gz
+# url = http://localhost:4444/hadoop-2.2.0.tar.gz
+
+## doesn't work here since only only processes local to the installation folder are checked
+#postInstallCmds = "mkdir -p $HADOOP_INSTALL/mydata/hdfs/namenode", "mkdir -p $HADOOP_INSTALL/mydata/hdfs/datanode"
+
+controllerPath = controller.json
+extractCmd = tar --strip 1 -xf
+
+
+# the folder used to define the overlay files which are either static files or MVEL templates
+# which are then overlaid on top of the installation
+overlayFolder = overlayFiles
+
+disableDynamicPorts = STORAGE,SSL_STORAGE,NATIVE_TRANSPORT,RPC

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.environment.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.environment.properties
@@ -1,0 +1,30 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+# use this to customise the listen address that cassandra listens on
+# since Cassandra currently demands all nodes use the same RPC port, we must use a different listen address
+# per container
+#FABRIC8_LISTEN_ADDRESS = localhost
+
+HADOOP_INSTALL = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_MAPRED_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_COMMON_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_HDFS_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+YARN_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_COMMON_LIB_NATIVE_DIR = ${env:FABRIC8_PROCESS_INSTALL_DIR}/lib/native
+HADOOP_OPTS=-Djava.library.path=${env:FABRIC8_PROCESS_INSTALL_DIR}/lib -javaagent:jolokia-agent.jar=host=0.0.0.0,port=${env:FABRIC8_JOLOKIA_PROXY_PORT},agentId=${env:FABRIC8_KARAF_NAME}
+
+
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.ports.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.ports.properties
@@ -1,0 +1,33 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+# list of ports and their names and default values
+# which will be exported as an environment variable
+# FABRIC8_$NAME_PORT
+
+#SSHD = 22
+
+STORAGE = 7000
+SSL_STORAGE = 7001
+
+RMI = 7199
+
+JOLOKIA = 8778
+
+NATIVE_TRANSPORT = 9042
+RPC = 9160
+
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.template.variables.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.template.variables.properties
@@ -1,0 +1,20 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+# TODO the following should be of the form
+# <ip1>,<ip2>,<ip3> if using multiple containers
+namenode_dir = ${env:FABRIC8_PROCESS_INSTALL_DIR}/mydata/hdfs/namenode
+datanode_dir = ${env:FABRIC8_PROCESS_INSTALL_DIR}/mydata/hdfs/datanode

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.zookeeper.publish-listen.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.zookeeper.publish-listen.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+path = /fabric/registry/clusters/cassandra/${env:FABRIC_CASSANDRA_CLUSTER}/${env:FABRIC8_CONTAINER_NAME}/listen
+publishValue = ${env:FABRIC8_LISTEN_ADDRESS}
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/core-site.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/core-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>fs.default.name</name>
+        <value>hdfs://localhost:9000</value>
+    </property>
+</configuration>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/hdfs-site.xml.mvel
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/hdfs-site.xml.mvel
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+    <property>
+        <name>dfs.namenode.name.dir</name>
+ <!--       <value>file:/home/pantinor/mydata/hdfs/namenode</value> -->
+        <value>file:@{namenode_dir}</value>
+    </property>
+    <property>
+        <name>dfs.datanode.data.dir</name>
+ <!--       <value>file:/home/pantinor/mydata/hdfs/datanode</value> -->
+        <value>file:@{datanode_dir}</value>
+    </property>
+</configuration>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/mapred-site.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/mapred-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/yarn-site.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/overlayFiles/etc/hadoop/yarn-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<configuration>
+
+    <!-- Site specific YARN configuration properties -->
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+    <property>
+        <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
+        <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+    </property>
+
+</configuration>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/ReadMe.md
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/ReadMe.md
@@ -1,0 +1,6 @@
+## HDFS
+
+This profile lets you create an Hadoop File System 2.2 containers on your network with the role of NameNode.
+
+Since the profile has to download ~80MB from the internet that it cannot cache, be aware that each installation might take a while.
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/controller.json
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/controller.json
@@ -1,0 +1,8 @@
+{
+    "startCommand": " sh -c \" exec bin/hdfs --config $HADOOP_INSTALL/etc/hadoop namenode & 2>&1 ; echo $! > namenode.pid  \"  ",
+    "pidFile": "namenode.pid",
+    "installCommands": [
+        "mkdir -p $HADOOP_INSTALL/mydata/hdfs/namenode  $HADOOP_INSTALL/mydata/hdfs/datanode",
+        " sh -c \" bin/hdfs namenode -format \" "
+    ]
+}

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.container.process.overlay.resources.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.container.process.overlay.resources.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+# specify the name inside the process distribution as the key and the value is the URL to download the file
+
+jolokia-agent.jar = mvn:org.jolokia/jolokia-jvm/1.2.1/jar/agent

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.container.process.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.container.process.properties
@@ -1,0 +1,32 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+processName = HDFS.namenode
+url = http://www.eu.apache.org/dist/hadoop/common/stable/hadoop-2.2.0.tar.gz
+# url = http://localhost:4444/hadoop-2.2.0.tar.gz
+
+## doesn't work here since only only processes local to the installation folder are checked
+#postInstallCmds = "mkdir -p $HADOOP_INSTALL/mydata/hdfs/namenode", "mkdir -p $HADOOP_INSTALL/mydata/hdfs/datanode"
+
+controllerPath = controller.json
+extractCmd = tar --strip 1 -xf
+
+
+# the folder used to define the overlay files which are either static files or MVEL templates
+# which are then overlaid on top of the installation
+overlayFolder = overlayFiles
+
+disableDynamicPorts = STORAGE,SSL_STORAGE,NATIVE_TRANSPORT,RPC

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.environment.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.environment.properties
@@ -1,0 +1,30 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+# use this to customise the listen address that cassandra listens on
+# since Cassandra currently demands all nodes use the same RPC port, we must use a different listen address
+# per container
+#FABRIC8_LISTEN_ADDRESS = localhost
+
+HADOOP_INSTALL = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_MAPRED_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_COMMON_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_HDFS_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+YARN_HOME = ${env:FABRIC8_PROCESS_INSTALL_DIR}
+HADOOP_COMMON_LIB_NATIVE_DIR = ${env:FABRIC8_PROCESS_INSTALL_DIR}/lib/native
+HADOOP_OPTS=-Djava.library.path=${env:FABRIC8_PROCESS_INSTALL_DIR}/lib -javaagent:jolokia-agent.jar=host=0.0.0.0,port=${env:FABRIC8_JOLOKIA_PROXY_PORT},agentId=${env:FABRIC8_KARAF_NAME}
+
+
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.ports.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.ports.properties
@@ -1,0 +1,33 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+# list of ports and their names and default values
+# which will be exported as an environment variable
+# FABRIC8_$NAME_PORT
+
+#SSHD = 22
+
+STORAGE = 7000
+SSL_STORAGE = 7001
+
+RMI = 7199
+
+JOLOKIA = 8778
+
+NATIVE_TRANSPORT = 9042
+RPC = 9160
+
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.template.variables.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.template.variables.properties
@@ -1,0 +1,20 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+# TODO the following should be of the form
+# <ip1>,<ip2>,<ip3> if using multiple containers
+namenode_dir = ${env:FABRIC8_PROCESS_INSTALL_DIR}/mydata/hdfs/namenode
+datanode_dir = ${env:FABRIC8_PROCESS_INSTALL_DIR}/mydata/hdfs/datanode

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.zookeeper.publish-listen.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.zookeeper.publish-listen.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+path = /fabric/registry/clusters/cassandra/${env:FABRIC_CASSANDRA_CLUSTER}/${env:FABRIC8_CONTAINER_NAME}/listen
+publishValue = ${env:FABRIC8_LISTEN_ADDRESS}
+

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/core-site.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/core-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>fs.default.name</name>
+        <value>hdfs://localhost:9000</value>
+    </property>
+</configuration>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/hdfs-site.xml.mvel
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/hdfs-site.xml.mvel
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+    </property>
+    <property>
+        <name>dfs.namenode.name.dir</name>
+ <!--       <value>file:/home/pantinor/mydata/hdfs/namenode</value> -->
+        <value>file:@{namenode_dir}</value>
+    </property>
+    <property>
+        <name>dfs.datanode.data.dir</name>
+ <!--       <value>file:/home/pantinor/mydata/hdfs/datanode</value> -->
+        <value>file:@{datanode_dir}</value>
+    </property>
+</configuration>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/mapred-site.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/mapred-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+    <property>
+        <name>mapreduce.framework.name</name>
+        <value>yarn</value>
+    </property>
+</configuration>

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/yarn-site.xml
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/overlayFiles/etc/hadoop/yarn-site.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<configuration>
+
+    <!-- Site specific YARN configuration properties -->
+    <property>
+        <name>yarn.nodemanager.aux-services</name>
+        <value>mapreduce_shuffle</value>
+    </property>
+    <property>
+        <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
+        <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+    </property>
+
+</configuration>

--- a/process/process-manager/src/main/java/io/fabric8/process/manager/support/ApplyConfigurationTask.java
+++ b/process/process-manager/src/main/java/io/fabric8/process/manager/support/ApplyConfigurationTask.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import io.fabric8.common.util.FileChangeInfo;
 import io.fabric8.process.manager.InstallContext;
+import io.fabric8.process.manager.service.ProcessManagerService;
 import io.fabric8.process.manager.support.mvel.MvelPredicate;
 import io.fabric8.process.manager.support.mvel.MvelTemplateRendering;
 import io.fabric8.process.manager.InstallTask;
@@ -46,6 +47,7 @@ public class ApplyConfigurationTask implements InstallTask {
     public void install(InstallContext installContext, ProcessConfig config, String id, File installDir) throws Exception {
         Map<String, String> templates = Maps.filterKeys(configuration, isTemplate);
         Map<String, String> plainFiles = Maps.difference(configuration, templates).entriesOnlyOnLeft();
+        ProcessManagerService.substituteEnvironmentVariableExpressions((Map)variables, config.getEnvironment());
         Map<String, String> renderedTemplates = Maps.transformValues(templates, new MvelTemplateRendering(variables));
         File baseDir = ProcessUtils.findInstallDir(installDir);
         applyTemplates(installContext, renderedTemplates, baseDir);

--- a/process/process-manager/src/main/resources/hdfs.json
+++ b/process/process-manager/src/main/resources/hdfs.json
@@ -1,0 +1,15 @@
+{
+    "startCommand": "sh -c \" exec bin/hdfs --config $HADOOP_INSTALL/etc/hadoop namenode & 2>&1 ; echo $! > namenode.pid \" ",
+    "pidFile": "namenode.pid",
+    "environment": {
+        "HADOOP_INSTALL": "/data/software/ext/hadoop-2.2.0",
+
+        "HADOOP_MAPRED_HOME": "$HADOOP_INSTALL",
+        "HADOOP_COMMON_HOME": "$HADOOP_INSTALL",
+        "HADOOP_HDFS_HOME": "$HADOOP_INSTALL",
+        "YARN_HOME": "$HADOOP_INSTALL",
+
+        "HADOOP_COMMON_LIB_NATIVE_DIR": "$HADOOP_INSTALL/lib/native",
+        "HADOOP_OPTS": "-Djava.library.path=$HADOOP_INSTALL/lib"
+    }
+}


### PR DESCRIPTION
HDFS: initial working example + additions and dirty hacks to Fabric8 code to
support recursive properties replacement. Added a couple of TODOs. A future refactoring is required to move `substituteEnvironmentVariableExpressions` static method to a common utility class that can be imported without introducing circular dependencies at maven level 

![screenshot from 2014-06-13 18 30 58](https://cloud.githubusercontent.com/assets/1520602/3285079/e27a5476-f534-11e3-9312-443e23388873.png)
