### PR TITLE
Added migration MD page.

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
     * [Maven Plugin](mavenPlugin.md)
     * [Debugging](debugging.md)
     * [Continuous Deployment](continuousDeployment.md)
+    * [Migration](migration.md)
 * [Architecture](registry.md)
     * [Registry](registry.md)
     * [Profiles](profiles.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@
 
 * <a href="developer.md">Developer Workflow</a>
 * <a href="mavenPlugin.md">Maven Plugin</a>
+* <a href="migration.md">Migration</a>
 
 ### Architecture
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,36 @@
+# Migration
+
+## Migrating profiles from the old Fabric8 instances
+
+If you try to migrate the older version of Fabric (let's say old
+[JBoss Fuse 6.0](http://www.jboss.org/products/fuse/overview) instance) to the new Fabric8 installation, you will
+notice that there is no `fabric8:zip` Maven command available for your old project. Maven tooling has been introduced
+in the more recent versions of the Fabric8, so you can't use the Maven plugin to export your profiles from the older
+Fabric8 instances.
+
+In order to migrate profiles from your older Fabric8 installations to the brand new Fabric8 instance, you need to:
+
+**Step 1**: Install new Fabric8 server:
+
+    unzip fabric8-karaf-1.1.0-SNAPSHOT.zip
+    mv fabric8-karaf-1.1.0-SNAPSHOT /opt/new-fabric8-home
+
+**Step 2**:Export the registry of your old Fabric8 instance using the `fabric:export` shell command
+
+    > fabric:export
+    Export to /opt/old-fabric8-home/fabric/export completed successfully
+
+**Step 3**: Copy the profiles you want to migrate into the `fabric/import/fabric/configs/versions` directory in your new Fabric
+instance
+
+     % cp -r /opt/old-fabric8-home/fabric/configs/versions/1.0/profiles/{foo,bar}  /opt/new-fabric8-home/fabric/import/fabric/configs/versions/1.0/profiles/
+
+**Step 4**: Start new Fabric server
+
+     % /opt/new-fabric8-home/bin/fabric8
+
+The `foo` and `bar` profiles will be automatically imported from the `new-fabric8-home/fabric/import` directory:
+
+    > profile-list | grep 'foo|bar'
+    foo                         0              default
+    bar                         0              default


### PR DESCRIPTION
Created dedicated section in the documentation where I will summarize techniques, tool and practices related to the process of migration of the existing Fabric8 installations into, for example, newer versions of Fabric8.
