### PR TITLE
#1788 let fabric-cxf explicitly import-package com.fasterxml.jackson.mod...

### DIFF
--- a/fabric/fabric-cxf/pom.xml
+++ b/fabric/fabric-cxf/pom.xml
@@ -33,6 +33,11 @@
         <fuse.osgi.export>
             io.fabric8.cxf*;version=${project.version},
         </fuse.osgi.export>
+        <fuse.osgi.import>
+            org.apache.cxf.management.jmx,                           
+            com.fasterxml.jackson.module.jaxb;resolution:=mandatory,
+            *
+        </fuse.osgi.import>
     </properties>
 
     <dependencies>
@@ -161,20 +166,6 @@
                     <forkMode>perTest</forkMode>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package>
-                           org.apache.cxf.management.jmx,
-                           *
-                        </Import-Package>
-                    </instructions>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/fabric/fabric-cxf/src/main/java/io/fabric8/cxf/endpoint/ManagedApi.java
+++ b/fabric/fabric-cxf/src/main/java/io/fabric8/cxf/endpoint/ManagedApi.java
@@ -633,11 +633,6 @@ public class ManagedApi implements ManagedComponent, ServerLifeCycleListener {
     public void stopServer(Server s) {
         if (server.equals(s)) {
             state = State.STOPPED;
-            // unregister server to avoid the memory leak
-            ServerLifeCycleManager mgr = bus.getExtension(ServerLifeCycleManager.class);
-            if (mgr != null) {
-                mgr.unRegisterListener(this);                
-            }
         }
     }
 }

--- a/fabric/fabric-cxf/src/main/java/io/fabric8/cxf/endpoint/ManagedApiFeature.java
+++ b/fabric/fabric-cxf/src/main/java/io/fabric8/cxf/endpoint/ManagedApiFeature.java
@@ -28,6 +28,7 @@ import org.apache.cxf.common.logging.LogUtils;
 import org.apache.cxf.endpoint.Endpoint;
 import org.apache.cxf.endpoint.EndpointImpl;
 import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.endpoint.ServerLifeCycleManager;
 import org.apache.cxf.endpoint.ServerRegistry;
 import org.apache.cxf.feature.AbstractFeature;
 import org.apache.cxf.feature.Feature;
@@ -44,6 +45,12 @@ public class ManagedApiFeature extends AbstractFeature {
         if (iMgr != null) {   
             try {
                 iMgr.register(mApi);
+                ServerLifeCycleManager slcMgr = bus.getExtension(ServerLifeCycleManager.class);
+                if (slcMgr != null) {
+                    slcMgr.registerListener(mApi);
+                    slcMgr.startServer(server);
+                }
+
             } catch (JMException jmex) {
                 jmex.printStackTrace();
                 LOG.log(Level.WARNING, "Registering ManagedApi failed.", jmex);


### PR DESCRIPTION
...ule.jaxb with resolution:=mandatory
#1791 CXF Endpoint ManagedApi should register Listener to ServerLifeCycleManager so that the getState is always correct
