### PR TITLE
quickstarts compiler error

### DIFF
--- a/quickstarts/camel-cdi-java/src/main/java/io/fabric8/quickstarts/fabric/camelcdi/MyRoutes.java
+++ b/quickstarts/camel-cdi-java/src/main/java/io/fabric8/quickstarts/fabric/camelcdi/MyRoutes.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.quickstarts.camelcdi;
+package io.fabric8.quickstarts.fabric.camelcdi;
 
 import javax.ejb.Startup;
 import javax.enterprise.context.ApplicationScoped;

--- a/quickstarts/camel-cdi-java/src/main/java/io/fabric8/quickstarts/fabric/camelcdi/SomeBean.java
+++ b/quickstarts/camel-cdi-java/src/main/java/io/fabric8/quickstarts/fabric/camelcdi/SomeBean.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.quickstarts.camelcdi;
+package io.fabric8.quickstarts.fabric.camelcdi;
 
 import javax.inject.Singleton;
 


### PR DESCRIPTION
fix import path. package structure & declared import path was not the same.
