### PR TITLE
#1770: fabric - profile-list - Should use a wider id column

### DIFF
--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/ProfileListAction.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/ProfileListAction.java
@@ -56,12 +56,12 @@ public class ProfileListAction extends AbstractAction {
     }
 
     protected void printProfiles(Profile[] profiles, PrintStream out) {
-        out.println(String.format("%-40s %-14s %s", "[id]", "[# containers]", "[parents]"));
+        out.println(String.format("%-50s %-14s %s", "[id]", "[# containers]", "[parents]"));
         for (Profile profile : profiles) {
             // skip profiles that do not exists (they may have been deleted)
             if (profile.exists() && (hidden || !profile.isHidden())) {
                 int active = profile.getAssociatedContainers().length;
-                out.println(String.format("%-40s %-14s %s", profile.getId(), active, toString(profile.getParents())));
+                out.println(String.format("%-50s %-14s %s", profile.getId(), active, toString(profile.getParents())));
             }
         }
     }


### PR DESCRIPTION
Before ...

![profile-list](https://cloud.githubusercontent.com/assets/1269759/3336897/f83fb654-f83e-11e3-856a-92c156fc2844.png)

After ..
![profile-list2](https://cloud.githubusercontent.com/assets/1269759/3336899/fa519412-f83e-11e3-9a6b-b3fba623b96e.png)
