### PR TITLE
FABRIC-1079 setting restart instructions as System property instead that...

### DIFF
--- a/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/JoinAction.java
+++ b/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/JoinAction.java
@@ -158,8 +158,8 @@ final class JoinAction extends AbstractAction {
                     installBundles();
                 }
                 //Restart the container
-                runtimeProperties.setProperty("karaf.restart", "true");
-                runtimeProperties.setProperty("karaf.restart.clean", "false");
+                System.setProperty("karaf.restart", "true");
+                System.setProperty("karaf.restart.clean", "false");
                 bundleContext.getBundle(0).stop();
 
                 return null;


### PR DESCRIPTION
... as Runtime property

Fixes https://issues.jboss.org/browse/FABRIC-1079
