### PR TITLE
ENTMQ-700 - NoNodeException can happen during the update when zk connect...

### DIFF
--- a/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
+++ b/fabric/fabric-groups/src/main/java/io/fabric8/groups/internal/ZooKeeperGroup.java
@@ -486,7 +486,9 @@ public class ZooKeeperGroup<T extends NodeState> implements Group<T> {
             String fullPath = ZKPaths.makePath(path, name);
 
             if ((mode == RefreshMode.FORCE_GET_DATA_AND_STAT) || !currentData.containsKey(fullPath)) {
-                getDataAndStat(fullPath);
+                try {
+                    getDataAndStat(fullPath);
+                } catch (KeeperException.NoNodeException ignore) {}
             }
         }
     }


### PR DESCRIPTION
...ion is unstable; we should ignore that as it can fail the whole update
