### PR TITLE
Fixes ENTESB-1695: HTTP Gateway leaks memory and file descriptors

### DIFF
--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/FutureHandler.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/detecting/FutureHandler.java
@@ -34,12 +34,12 @@ public class FutureHandler<T> implements Handler<T> {
         done.countDown();
     }
 
-    T await() throws InterruptedException {
+    public T await() throws InterruptedException {
         done.await();
         return event;
     }
 
-    T await(long timeout, TimeUnit unit) throws InterruptedException {
+    public T await(long timeout, TimeUnit unit) throws InterruptedException {
         if( done.await(timeout, unit) ) {
             return event;
         } else {

--- a/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/http/HttpGatewayHandler.java
+++ b/gateway/gateway-core/src/main/java/io/fabric8/gateway/handlers/http/HttpGatewayHandler.java
@@ -127,6 +127,7 @@ public class HttpGatewayHandler implements Handler<HttpServerRequest> {
                     }
 
                     LOG.info("Proxying request " + uri + " to service path: " + servicePath + " on service: " + proxyServiceUrl + " reverseServiceUrl: " + reverseServiceUrl);
+                    final HttpClient finalClient = client;
                     Handler<HttpClientResponse> responseHandler = new Handler<HttpClientResponse>() {
                         public void handle(HttpClientResponse clientResponse) {
                             if (LOG.isDebugEnabled()) {
@@ -146,6 +147,7 @@ public class HttpGatewayHandler implements Handler<HttpServerRequest> {
                             clientResponse.endHandler(new VoidHandler() {
                                 public void handle() {
                                     request.response().end();
+                                    finalClient.close();
                                 }
                             });
                         }

--- a/gateway/gateway-core/src/test/resources/log4j.properties
+++ b/gateway/gateway-core/src/test/resources/log4j.properties
@@ -20,7 +20,7 @@
 log4j.rootLogger=INFO, file, out
 
 log4j.logger.io.fabric=INFO
-log4j.logger.io.fabric8.gateway.handlers.detecting=WARN
+log4j.logger.io.fabric8.gateway=WARN
 log4j.logger.org.apache.activemq.apollo=WARN
 
 # CONSOLE appender not used by default


### PR DESCRIPTION
Added a burn in test for the HTTP gateway and found it would OOM or run out of file descriptors.  We now close the vert.x http client once we are done with it so that those resources can get released.
