### PR TITLE
fixes #2026 - servicemix-utils version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3326,7 +3326,7 @@
             <dependency>
                 <groupId>org.apache.servicemix</groupId>
                 <artifactId>servicemix-utils</artifactId>
-                <version>${servicemix-nmr-version}</version>
+                <version>${servicemix-utils-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.servicemix</groupId>


### PR DESCRIPTION
Changed to use ${servicemix-utils-version} for servicemix-utils dependency.
