### PR TITLE
Process - changed behavior for missing env_variable. Now they are kept...

### DIFF
--- a/fabric/fabric-process-container/src/main/java/io/fabric8/container/process/ProcessManagerController.java
+++ b/fabric/fabric-process-container/src/main/java/io/fabric8/container/process/ProcessManagerController.java
@@ -310,10 +310,10 @@ public class ProcessManagerController implements ChildContainerController {
         if (container != null) {
             registerPorts(options, processConfig, container, environmentVariables);
         }
-        JolokiaAgentHelper.substituteEnvironmentVariableExpressions(environmentVariables, environmentVariables, fabricService, curator);
+        JolokiaAgentHelper.substituteEnvironmentVariableExpressions(environmentVariables, environmentVariables, fabricService, curator, true);
         // in case there's any current system environment variables to replace
         // such as the operating system PATH or FABRIC8_JAVA8_HOME when not using docker containers
-        JolokiaAgentHelper.substituteEnvironmentVariableExpressions(environmentVariables, System.getenv(), null, null);
+        JolokiaAgentHelper.substituteEnvironmentVariableExpressions(environmentVariables, System.getenv(), null, null, true);
         publishZooKeeperValues(options, processConfig, container, environmentVariables);
 
         Installation installation = null;
@@ -457,7 +457,7 @@ public class ProcessManagerController implements ChildContainerController {
         Set<String> profileIds = options.getProfiles();
         String versionId = options.getVersion();
         Map<String, String> configuration = Profiles.getOverlayConfiguration(fabricService, profileIds, versionId, ChildConstants.PROCESS_CONTAINER_PID);
-        JolokiaAgentHelper.substituteEnvironmentVariableExpressions(configuration, environmentVariables, fabricService, curator);
+        JolokiaAgentHelper.substituteEnvironmentVariableExpressions(configuration, environmentVariables, fabricService, curator, true);
         ProcessContainerConfig configObject = new ProcessContainerConfig();
         configurer.configure(configuration, configObject);
         return configObject;
@@ -526,7 +526,7 @@ public class ProcessManagerController implements ChildContainerController {
                 if (variables == null) {
                     variables = new HashMap();
                 } else {
-                    JolokiaAgentHelper.substituteEnvironmentVariableExpressions(variables, environmentVariables, fabricService, curator);
+                    JolokiaAgentHelper.substituteEnvironmentVariableExpressions(variables, environmentVariables, fabricService, curator, true);
                 }
                 variables.putAll(environmentVariables);
                 LOG.info("Using template variables for MVEL: " + variables);
@@ -661,7 +661,7 @@ public class ProcessManagerController implements ChildContainerController {
             Map<String, String> exportConfig = entry.getValue();
 
             if (exportConfig != null && !exportConfig.isEmpty()) {
-                JolokiaAgentHelper.substituteEnvironmentVariableExpressions(exportConfig, environmentVariables, fabricService, curator);
+                JolokiaAgentHelper.substituteEnvironmentVariableExpressions(exportConfig, environmentVariables, fabricService, curator, true);
                 ZooKeeperPublishConfig config = new ZooKeeperPublishConfig();
                 try {
                     configurer.configure(exportConfig, config);

--- a/fabric/fabric-zookeeper/src/test/java/io/fabric8/zookeeper/utils/InterpolationHelperTest.java
+++ b/fabric/fabric-zookeeper/src/test/java/io/fabric8/zookeeper/utils/InterpolationHelperTest.java
@@ -1,0 +1,99 @@
+/**
+ *  Copyright 2005-2014 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.zookeeper.utils;
+
+import io.fabric8.zookeeper.ZkPath;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.zookeeper.server.NIOServerCnxnFactory;
+import org.apache.zookeeper.server.ServerConfig;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.apache.zookeeper.server.persistence.FileTxnSnapLog;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.StringReader;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class InterpolationHelperTest {
+
+    InterpolationHelper.SubstitutionCallback dummyCallback;
+
+
+    @Before
+    public void init() throws Exception {
+        dummyCallback = new InterpolationHelper.SubstitutionCallback(){
+            public String getValue(String key) {
+                return null;
+            }};
+
+
+    }
+
+
+    @Test
+    public void testSubstVars() throws Exception {
+
+        String val = "#${propName}#";
+        String currentKey = "";
+        Map<String, String> cycleMap = new HashMap<>();
+        Map<String, String> configProps = new HashMap<>();
+        configProps.put("propName", "OK");
+        InterpolationHelper.SubstitutionCallback callback = this.dummyCallback;
+
+        String result = InterpolationHelper.substVars(val, currentKey, cycleMap, configProps, callback );
+
+        assertThat(result, equalTo("#OK#"));
+
+        val = "#${ANOTHERpropName}#";
+        result = InterpolationHelper.substVars(val, currentKey, cycleMap, configProps, callback );
+        assertThat(result, equalTo("##"));
+
+
+    }
+
+    @Test
+    public void testSubstVarsPreserveUnresolved() throws Exception {
+
+        String val = "#${propName}#";
+        String currentKey = "";
+        Map<String, String> cycleMap = new HashMap<>();
+        Map<String, String> configProps = new HashMap<>();
+        configProps.put("propName", "OK");
+        InterpolationHelper.SubstitutionCallback callback =  this.dummyCallback;
+
+        String result = InterpolationHelper.substVarsPreserveUnresolved(val, currentKey, cycleMap, configProps, callback );
+
+        assertThat(result, equalTo("#OK#"));
+
+        val = "#${ANOTHERpropName}#";
+        result = InterpolationHelper.substVarsPreserveUnresolved(val, currentKey, cycleMap, configProps, callback );
+        assertThat(result, equalTo(val));
+    }
+
+
+}

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.container.process.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.datanode.profile/io.fabric8.container.process.properties
@@ -15,8 +15,8 @@
 #
 
 processName = HDFS.datanode
-url = http://www.eu.apache.org/dist/hadoop/common/stable/hadoop-2.2.0.tar.gz
-# url = http://localhost:4444/hadoop-2.2.0.tar.gz
+# url = http://www.eu.apache.org/dist/hadoop/common/stable/hadoop-2.2.0.tar.gz
+url = http://localhost:4444/hadoop-2.2.0.tar.gz
 
 ## doesn't work here since only only processes local to the installation folder are checked
 #postUnpackCmds = "mkdir -p $HADOOP_INSTALL/mydata/hdfs/namenode", "mkdir -p $HADOOP_INSTALL/mydata/hdfs/datanode"

--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.container.process.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/services/hdfs.namenode.profile/io.fabric8.container.process.properties
@@ -15,8 +15,8 @@
 #
 
 processName = HDFS.namenode
-url = http://www.eu.apache.org/dist/hadoop/common/stable/hadoop-2.2.0.tar.gz
-# url = http://localhost:4444/hadoop-2.2.0.tar.gz
+# url = http://www.eu.apache.org/dist/hadoop/common/stable/hadoop-2.2.0.tar.gz
+url = http://localhost:4444/hadoop-2.2.0.tar.gz
 
 ## doesn't work here since only only processes local to the installation folder are checked
 #postUnpackCmds = "mkdir -p $HADOOP_INSTALL/mydata/hdfs/namenode", "mkdir -p $HADOOP_INSTALL/mydata/hdfs/datanode"


### PR DESCRIPTION
... unreplaced. Needed for specific profiles that require to know the installation folder.
- manually tested with the following profiles: hdfs, cassandra, docker containers

fixes #2046
