### PR TITLE
Removed insight-maven dependency from archetype-builder POM.

### DIFF
--- a/tooling/archetype-builder/pom.xml
+++ b/tooling/archetype-builder/pom.xml
@@ -75,13 +75,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.fabric8.insight</groupId>
-            <artifactId>insight-maven</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
             <version>3.0.5</version>


### PR DESCRIPTION
`insight-maven` seems not to be used at all in the `archetype-builder` project. On the other hand it causes build problems, because `archetype-builder` is always built while `insight-maven` is built only when `all` profile is active. It means that executing `mvn install` without `all` on fresh Fabric8 installation leads to "artifact insight-maven not found" error.

Feel free to revert if I'm missing something :) .
