### PR TITLE
Use unique container names in ExtendedUpgradeAndRollbackTest

### DIFF
--- a/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedUpgradeAndRollbackTest.java
+++ b/itests/basic/karaf/src/test/java/io/fabric8/itests/basic/karaf/ExtendedUpgradeAndRollbackTest.java
@@ -104,7 +104,7 @@ public class ExtendedUpgradeAndRollbackTest  {
         try {
             FabricService fabricService = fabricProxy.getService();
             System.out.println(CommandSupport.executeCommand("fabric:version-create --parent 1.0 1.1"));
-            Set<Container> containers = ContainerBuilder.create().withName("camel").withProfiles("feature-camel").assertProvisioningResult().build(fabricService);
+            Set<Container> containers = ContainerBuilder.create().withName("basic.camelA").withProfiles("feature-camel").assertProvisioningResult().build(fabricService);
             try {
                 //Make sure that the profile change has been applied before changing the version
                 CountDownLatch latch = WaitForConfigurationChange.on(fabricService);
@@ -130,10 +130,10 @@ public class ExtendedUpgradeAndRollbackTest  {
                     String bundles = CommandSupport.executeCommand("fabric:container-connect -u admin -p admin " + container.getId() + " osgi:list -s | grep camel-hazelcast");
                     Assert.assertNotNull(bundles);
                     System.out.println(bundles);
-                    Assert.assertTrue("Expected no camel-hazelcast installed on container:"+container.getId()+".", bundles.isEmpty());
+                    Assert.assertTrue("Expected no camel-hazelcast installed on container:" + container.getId() + ".", bundles.isEmpty());
                 }
             } finally {
-                ContainerBuilder.destroy(fabricService, containers);
+                ContainerBuilder.stop(fabricService, containers);
             }
         } finally {
             fabricProxy.close();
@@ -158,7 +158,7 @@ public class ExtendedUpgradeAndRollbackTest  {
             FabricService fabricService = fabricProxy.getService();
             System.out.println(CommandSupport.executeCommand("fabric:version-create --parent 1.0 1.1"));
             System.out.println(CommandSupport.executeCommand("fabric:container-upgrade --all 1.1"));
-            Set<Container> containers = ContainerBuilder.create().withName("camel").withProfiles("feature-camel").assertProvisioningResult().build(fabricService);
+            Set<Container> containers = ContainerBuilder.create().withName("basic.camelB").withProfiles("feature-camel").assertProvisioningResult().build(fabricService);
             try {
                 System.out.println(CommandSupport.executeCommand("fabric:container-rollback --all 1.0"));
                 ProvisionSupport.provisioningSuccess(containers, ProvisionSupport.PROVISION_TIMEOUT);
@@ -167,7 +167,7 @@ public class ExtendedUpgradeAndRollbackTest  {
                     Assert.assertNotNull(ZooKeeperUtils.exists(ServiceLocator.awaitService(CuratorFramework.class), "/fabric/configs/versions/1.0/containers/" + container.getId()));
                 }
             } finally {
-                ContainerBuilder.destroy(fabricService, containers);
+                ContainerBuilder.stop(fabricService, containers);
             }
         } finally {
             fabricProxy.close();


### PR DESCRIPTION
Intermittently fails in second test because the container from the first test (with the same name) is being destroyed
