### PR TITLE
see #2266

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/default.profile/io.fabric8.mq.fabric.server-broker.properties
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/mq/default.profile/io.fabric8.mq.fabric.server-broker.properties
@@ -14,7 +14,7 @@
 #  permissions and limitations under the License.
 #
 
-connectors=openwire
+connectors=openwire stomp mqtt amqp
 config=profile\:broker.xml
 config.checksum=${checksum:profile\:broker.xml}
 group=default


### PR DESCRIPTION
... well as that is what we have in the broker.xml. This is needed by MQ gateway so it knows about all those connectors. Thanks to @ugol for spotting this.
