### PR TITLE
pull xerces from central

### DIFF
--- a/fabric/fabric8-karaf/pom.xml
+++ b/fabric/fabric8-karaf/pom.xml
@@ -345,7 +345,7 @@
 
          <!-- these are copied to the lib folder -->
         <dependency>
-            <groupId>org.apache.xerces</groupId>
+            <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>${xerces.version}</version>
         </dependency>
@@ -664,7 +664,7 @@
                              <organizationURL>http://redhat.com</organizationURL>
                              <preamble>In addition to the Red Hat products, this disk contains certain third party software or components (“Third Party Components”), which are bundled as separate files or modules and separately licensed to you by said third parties. This file contains a listing of all NOTICE/NOTICE.txt files included with the Third Party Component jars in this distribution of Fabric8. Please see the fabric_dependencies.txt file for the complete listing of Third Party Components and their attributed license agreements.  Your use of the Third Party Components is subject to the terms and conditions set forth in the applicable third party license agreement.  The Third Party Components are provided by Red Hat Inc. solely on an "AS IS" basis, without any warranty.  Red Hat, Inc. disclaims all warranties and indemnities with respect to the Third Party Components, express or implied, and assumes no liability with respect to the Third Party Components.  You acknowledge that the authors of the Third Party Components have no obligation to provide support to you for the Third Party Components.  You hereby undertake to comply with all licenses related to the applicable Third Party Components. All third party license agreements are contained in the licenses directory of </preamble>
                              <listDependencies>true</listDependencies>
-                             <extraDependencies>org.apache.xerces:xercesImpl:${xerces.version},xalan:xalan:${xalan.version},xalan:serializer:${xalan.version},org.apache.servicemix.specs:org.apache.servicemix.specs.activator:${servicemix-specs-version},org.apache.servicemix.specs:org.apache.servicemix.specs.jaxp-api-1.4:${servicemix-specs-version},org.apache.servicemix.specs:org.apache.servicemix.specs.jaxws-api-2.2:${servicemix-specs-version}</extraDependencies>
+                             <extraDependencies>xerces:xercesImpl:${xerces.version},xalan:xalan:${xalan.version},xalan:serializer:${xalan.version},org.apache.servicemix.specs:org.apache.servicemix.specs.activator:${servicemix-specs-version},org.apache.servicemix.specs:org.apache.servicemix.specs.jaxp-api-1.4:${servicemix-specs-version},org.apache.servicemix.specs:org.apache.servicemix.specs.jaxws-api-2.2:${servicemix-specs-version}</extraDependencies>
                              <noticeSupplements>classes/notice-supplements.xml</noticeSupplements>
                              <repositories>${project.basedir}/target/features-repo</repositories>
                              <defaultParent>io.fabric8:fabric-project:${project.version}:../..</defaultParent>
@@ -841,20 +841,6 @@
            	</plugins>
            </pluginManagement>
        </build>
-
-    <repositories>
-        <!-- needed for xerces -->
-        <repository>
-            <id>servicemix.m2-repo</id>
-            <name>ServiceMix Maven 2 repository</name>
-            <url>http://svn.apache.org/repos/asf/servicemix/m2-repo</url>
-        </repository>
-		<repository>
-	        <id>shibboleth-public</id>
-	        <name>Shibboleth Public</name>
-			<url>http://build.shibboleth.net/nexus/content/repositories/public/</url>
-		</repository>
-    </repositories>
 
     <profiles>
     </profiles>


### PR DESCRIPTION
When getting the project to build in my environment (I have a Nexus catchall proxy) I noticed a few repositories that do not seem to be needed anymore.

Historically xerces has been [a bit of a headache](http://stackoverflow.com/questions/11677572/dealing-with-xerces-hell-in-java-maven), but since Feb 13 it has been in central.  This means shibboleth-public repo is no longer needed.

The servicemix.m2-repo was unused so that has been removed too.
