### PR TITLE
Fixed WAR detection to be DASH-compatible.

### DIFF
--- a/process/process-launcher/src/main/distro/bin/launcher
+++ b/process/process-launcher/src/main/distro/bin/launcher
@@ -72,7 +72,7 @@ APP_CONSOLE_ERR="${APP_BASE}/logs/err.log"
 
 # Add the jars in the lib dir
 CLASSPATH=""
-for file in "$APP_BASE"/lib/*.{jar,war}
+for file in "$APP_BASE"/lib/*.jar "$APP_BASE"/lib/*.war
 do
     if [ -z "$CLASSPATH" ]; then
         CLASSPATH="$file"


### PR DESCRIPTION
Ubuntu uses Dash [1] as the POSIX-compliant shell. Dash doesn't support `foo,bar` notation, so launcher won't work under Ubuntu. I've expanded WAR detection to be DASH friendly.   

[1] http://en.wikipedia.org/wiki/Almquist_shell
