### PR TITLE
Make sure overridden resources are only used if the original resource is...

### DIFF
--- a/fabric/fabric-agent/src/main/java/io/fabric8/agent/DeploymentBuilder.java
+++ b/fabric/fabric-agent/src/main/java/io/fabric8/agent/DeploymentBuilder.java
@@ -170,7 +170,7 @@ public class DeploymentBuilder {
         downloader.await();
         // Do override replacement
         for (String override : overrides) {
-            Resource over = resources.get(extractUrl(override));
+            Resource over = resources.remove(extractUrl(override));
             if (over == null) {
                 // Ignore invalid overrides
                 continue;


### PR DESCRIPTION
... referenced
