### PR TITLE
Handle eventual spaces in .karaf input config files. Replacement stopped...

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/internal/ContainerProviderUtils.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/internal/ContainerProviderUtils.java
@@ -161,7 +161,8 @@ public final class ContainerProviderUtils {
             lines.add(ZkDefs.MANUAL_IP + "=" + options.getManualIp());
         }
         appendFile(sb, "etc/system.properties", lines);
-        replaceLineInFile(sb, "etc/system.properties", "karaf.name=root", "karaf.name=" + name);
+        // backslash s , to handle any possible space
+        replaceLineInFile(sb, "etc/system.properties", "karaf.name\\s*=\\s*root", "karaf.name=" + name);
         for (Map.Entry<String, String> entry : options.getDataStoreProperties().entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();


### PR DESCRIPTION
... working after Karaf 2.4 that introduced spaces around the 'equals' symbol that the 'sed' manipulation wasn't expecting.

Fixes #2401
