### PR TITLE
[FABRIC-1134] Add initial support for ZooKeeper readonly mode. Which all...

### DIFF
--- a/fabric/fabric-git/src/main/java/io/fabric8/git/internal/GitDataStoreImpl.java
+++ b/fabric/fabric-git/src/main/java/io/fabric8/git/internal/GitDataStoreImpl.java
@@ -100,6 +100,7 @@ import org.apache.felix.scr.annotations.Deactivate;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
+import org.apache.zookeeper.KeeperException;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -283,7 +284,14 @@ public final class GitDataStoreImpl extends AbstractComponent implements GitData
                 }
             }
         });
-        counter.start();
+        try {
+            counter.start();
+        } catch (KeeperException.NotReadOnlyException ex) {
+            //In read only mode the counter is not going to start.
+            //If the connection is reestablished the component will reactivate.
+            //We need to catch this error so that the component gets activated.
+        }
+
 
         //It is not safe to assume that we will get notified by the ShareCounter, if the component is not activated
         // when the SharedCounter gets updated.

--- a/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/curator/ManagedCuratorFramework.java
+++ b/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/curator/ManagedCuratorFramework.java
@@ -129,7 +129,7 @@ public final class ManagedCuratorFramework extends AbstractComponent implements 
 
         @Override
         public void stateChanged(CuratorFramework client, ConnectionState newState) {
-            if (newState == ConnectionState.CONNECTED) {
+            if (newState == ConnectionState.CONNECTED || newState == ConnectionState.READ_ONLY || newState == ConnectionState.RECONNECTED) {
                 if (registration == null) {
                     registration = bundleContext.registerService(CuratorFramework.class, curator, null);
                 }
@@ -214,6 +214,7 @@ public final class ManagedCuratorFramework extends AbstractComponent implements 
      */
     private synchronized CuratorFramework buildCuratorFramework(CuratorConfig curatorConfig) {
         CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder()
+                .canBeReadOnly(true)
                 .ensembleProvider(new FixedEnsembleProvider(curatorConfig.getZookeeperUrl()))
                 .connectionTimeoutMs(curatorConfig.getZookeeperConnectionTimeOut())
                 .sessionTimeoutMs(curatorConfig.getZookeeperSessionTimeout())

--- a/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/utils/ZooKeeperUtils.java
+++ b/fabric/fabric-zookeeper/src/main/java/io/fabric8/zookeeper/utils/ZooKeeperUtils.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.zookeeper.utils;
 
+import io.fabric8.api.FabricException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.ChildData;
 import org.apache.curator.framework.recipes.cache.TreeCache;
@@ -473,6 +474,8 @@ public final class ZooKeeperUtils {
                 setData(curator, CONTAINERS_NODE + "/" + container, password);
                 lastTokenGenerationTime = time;
             }
+        } catch (KeeperException.NotReadOnlyException e) {
+            throw new FabricException("ZooKeeper server is partitioned. Currently working in read-only mode!");
         } catch (RuntimeException rte) {
             throw rte;
         } catch (Exception ex) {

--- a/fabric/fabric8-karaf/src/main/append-resources/common/etc/system.properties
+++ b/fabric/fabric8-karaf/src/main/append-resources/common/etc/system.properties
@@ -30,6 +30,7 @@ runtime.home=${karaf.home}
 runtime.conf=${karaf.etc}
 runtime.data=${karaf.data}
 zookeeper.sasl.client=false
+readonlymode.enabled=true
 
 org.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
 com.sun.org.apache.xml.internal.dtm.DTMManager=com.sun.org.apache.xml.internal.dtm.ref.DTMManagerDefault

--- a/runtime/container/tomcat/patch/scripts/antrun-tomcat-patch.xml
+++ b/runtime/container/tomcat/patch/scripts/antrun-tomcat-patch.xml
@@ -103,6 +103,7 @@
           runtime.conf=${catalina.home}/conf
           runtime.data=${catalina.home}/work
           zookeeper.sasl.client=false
+          readonlymode.enabled=true
     </echo>
 
   	<!-- Zip the tomcat patch -->

--- a/runtime/container/wildfly/patch/etc/wildfly/standalone/configuration/standalone-fabric.xml
+++ b/runtime/container/wildfly/patch/etc/wildfly/standalone/configuration/standalone-fabric.xml
@@ -55,6 +55,7 @@
         <property name="runtime.data" value="${jboss.home.dir}/standalone/data"/>
         <property name="jboss.bind.address.management" value="0.0.0.0"/>
         <property name="zookeeper.sasl.client" value="false"/>
+        <property name="readonlymode.enabled" value="true"/>
     </system-properties>
 
     <management>


### PR DESCRIPTION
...ows clients to stay connected to partitioned servers as read only clients, in order to perform recovery operations.
