### PR TITLE
karaf shell command to edit jvmOpts for child and ssh karaf containers

### DIFF
--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerEditJvmOptions.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerEditJvmOptions.java
@@ -1,0 +1,80 @@
+/**
+ *  Copyright 2005-2014 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.commands;
+
+import io.fabric8.api.FabricService;
+import io.fabric8.api.scr.ValidatingReference;
+import io.fabric8.boot.commands.support.AbstractCommandComponent;
+import io.fabric8.boot.commands.support.ContainerCompleter;
+import org.apache.felix.gogo.commands.Action;
+import org.apache.felix.gogo.commands.basic.AbstractCommand;
+import org.apache.felix.scr.annotations.*;
+import org.apache.felix.service.command.Function;
+
+@Component(immediate = true)
+@Service({ Function.class, AbstractCommand.class })
+@org.apache.felix.scr.annotations.Properties({
+        @Property(name = "osgi.command.scope", value = ContainerEditJvmOptions.SCOPE_VALUE),
+        @Property(name = "osgi.command.function", value = ContainerEditJvmOptions.FUNCTION_VALUE)
+})
+public class ContainerEditJvmOptions extends AbstractCommandComponent {
+
+    public static final String SCOPE_VALUE = "fabric";
+    public static final String FUNCTION_VALUE =  "container-edit-jvm-options";
+    public static final String DESCRIPTION = "Get or set the configured JVM options for a specific container";
+
+    @Reference(referenceInterface = FabricService.class)
+    private final ValidatingReference<FabricService> fabricService = new ValidatingReference<FabricService>();
+
+    // Completers
+    @Reference(referenceInterface = ContainerCompleter.class, bind = "bindContainerCompleter", unbind = "unbindContainerCompleter")
+    private ContainerCompleter containerCompleter; // dummy field
+
+
+    @Activate
+    void activate() {
+        activateComponent();
+    }
+
+    @Deactivate
+    void deactivate() {
+        deactivateComponent();
+    }
+
+    @Override
+    public Action createNewAction() {
+        assertValid();
+        return new ContainerEditJvmOptionsAction(fabricService.get());
+    }
+
+    void bindFabricService(FabricService fabricService) {
+        this.fabricService.bind(fabricService);
+    }
+
+    void unbindFabricService(FabricService fabricService) {
+        this.fabricService.unbind(fabricService);
+    }
+
+    void bindContainerCompleter(ContainerCompleter completer) {
+        bindCompleter(completer);
+    }
+
+    void unbindContainerCompleter(ContainerCompleter completer) {
+        unbindCompleter(completer);
+    }
+
+
+}

--- a/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerEditJvmOptionsAction.java
+++ b/fabric/fabric-commands/src/main/java/io/fabric8/commands/ContainerEditJvmOptionsAction.java
@@ -1,0 +1,236 @@
+/**
+ *  Copyright 2005-2014 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.commands;
+
+import io.fabric8.api.Container;
+import io.fabric8.api.CreateContainerMetadata;
+import io.fabric8.api.FabricAuthenticationException;
+import io.fabric8.api.FabricService;
+import io.fabric8.boot.commands.support.FabricCommand;
+import io.fabric8.utils.shell.ShellUtils;
+import org.apache.felix.gogo.commands.Argument;
+import org.apache.felix.gogo.commands.Command;
+import org.apache.felix.gogo.commands.Option;
+import org.apache.karaf.shell.console.AbstractAction;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import static io.fabric8.utils.FabricValidations.validateContainerName;
+
+@Command(name = ContainerEditJvmOptions.FUNCTION_VALUE, scope = ContainerEditJvmOptions.SCOPE_VALUE, description = ContainerEditJvmOptions.DESCRIPTION)
+public class ContainerEditJvmOptionsAction extends AbstractAction {
+
+    public static final String KARAF_ADMIN_OBJECT_NAME = "org.apache.karaf:type=admin,name=%s";
+    public static final String FABRIC_OBJECT_NAME = "io.fabric8:type=Fabric";
+    public static final String JAVA_LANG_OBJECT_NAME = "java.lang:type=Runtime";
+    public static final String OPERATION_CHILD = "changeJavaOpts";
+    public static final String OPERATION_SSH = "changeCreateOptionsField";
+
+    @Argument(index = 0, name = "containerName", description = "The name of the container.", required = true, multiValued = false)
+    private String container;
+    @Argument(index = 1, name = "jvmOptions", description = "The default JVM options to use, or empty to show current.", required = false, multiValued = false)
+    private String jvmOptions;
+
+    @Option(name = "-u", aliases = {"--username"}, description = "Remote user name", required = false, multiValued = false)
+    private String username;
+
+    @Option(name = "-p", aliases = {"--password"}, description = "Remote user password", required = false, multiValued = false)
+    private String password;
+
+    private final FabricService fabricService;
+
+
+    ContainerEditJvmOptionsAction(FabricService fabricService) {
+        this.fabricService = fabricService;
+
+    }
+
+    protected Object doExecute() throws Exception {
+
+        validateContainerName(container);
+
+        if (!FabricCommand.doesContainerExist(fabricService, container)) {
+            System.out.println("Container " + container + " does not exists!");
+            return null;
+        }
+
+        Container containerInstance = FabricCommand.getContainerIfExists(fabricService, container);
+        String type = containerInstance.getType();
+
+        if (!"karaf".equals(type)) {
+            System.out.println("Sorry, currently only \"karaf\" type container are supported");
+            return null;
+        }
+
+        String jmxUrl = null;
+        JMXConnector connector = null;
+        MBeanServerConnection remote = null;
+        HashMap<String, String[]> authenticationData = null;
+
+        jmxUrl = containerInstance.getJmxUrl();
+        authenticationData = prepareAuthenticationData();
+
+        try {
+            connector = connectOrRetry(authenticationData, jmxUrl);
+        } catch (Exception e){
+            username = null;
+            password = null;
+            System.out.println("Operation Failed. Check logs.");
+            log.error("Unable to connect to JMX Server", e);
+            return null;
+        }
+
+        remote = connector.getMBeanServerConnection();
+
+        ObjectName objName = null;
+        if (jvmOptions == null) {
+            objName = new ObjectName(JAVA_LANG_OBJECT_NAME);
+
+            try {
+                String[] arguments = (String[]) remote.getAttribute(objName, "InputArguments");
+                String output = Arrays.toString(arguments);
+                output = output.replaceAll(",", "");
+                output = output.substring(1, output.length() - 1);
+                System.out.println(output);
+            } catch (Exception e) {
+                System.out.println("Operation Failed. Check logs.");
+                log.error("Unable to fetch child jvm opts", e);
+            }
+
+        } else {
+            jvmOptions = stripSlashes(jvmOptions);
+
+            String providerType = null;
+            CreateContainerMetadata<?> metadata = containerInstance.getMetadata();
+            if(metadata == null){
+                //root container
+                //disallowed for the time being. something odd screws authentication
+                // providerType = "child";
+                System.out.println("Modifying current container is not allowed. Please turn the instance off and manually edit env variables");
+                return null;
+            }else{
+                providerType = metadata.getCreateOptions().getProviderType();
+            }
+
+
+            switch(providerType){
+                case "ssh":
+                    //we need to operate on an ensamble member container
+                    containerInstance= fabricService.getCurrentContainer();
+
+                    jmxUrl = containerInstance.getJmxUrl();
+                    authenticationData = prepareAuthenticationData();
+
+                    connector = connectOrRetry(authenticationData, jmxUrl);
+                    remote = connector.getMBeanServerConnection();
+
+                    objName = new ObjectName(String.format(FABRIC_OBJECT_NAME, container));
+
+                    try {
+                        remote.invoke(objName, OPERATION_SSH, new Object[]{container,  "jvmOpts", jvmOptions},
+                                new String[]{String.class.getName(), String.class.getName(), Object.class.getName()});
+                        System.out.println("Operation succeeded. New JVM flags will be loaded at the next start of " + container + " container");
+                        log.info("Updated JVM flags for container {}", container);
+                    } catch (Exception e) {
+                        System.out.println("Operation Failed. Check logs.");
+                        log.error("Unable to set ssh jvm opts", e);
+                    }
+                    break;
+
+                case "child":
+                    objName = new ObjectName(String.format(KARAF_ADMIN_OBJECT_NAME, container));
+
+                    try {
+                        remote.invoke(objName, OPERATION_CHILD, new Object[]{container, jvmOptions},
+                                new String[]{String.class.getName(), String.class.getName()});
+                        System.out.println("Operation succeeded. New JVM flags will be loaded at the next start of " + container + " container");
+                        log.info("Updated JVM flags for container {}", container);
+                    } catch (Exception e) {
+                        System.out.println("Operation Failed. Check logs.");
+                        log.error("Unable to set child jvm opts", e);
+                    }
+                    break;
+                default:
+                    System.out.println(String.format("Operation aborted. %s containers are not supported", providerType));
+            }
+
+        }
+
+        try{
+            connector.close();
+        } catch(IOException e){
+            log.error("Errors closing remote MBean connection", e);
+        }
+
+        return null;
+
+    }
+
+    private HashMap<String, String[]> prepareAuthenticationData() {
+        username = username != null && !username.isEmpty() ? username : ShellUtils.retrieveFabricUser(session);
+        password = password != null ? password : ShellUtils.retrieveFabricUserPassword(session);
+        String[] credentials = new String[]{username, password};
+
+        HashMap<String, String[]> env = new HashMap<String, String[]>();
+        env.put(JMXConnector.CREDENTIALS, credentials);
+        return env;
+    }
+
+    private JMXConnector connectOrRetry(HashMap<String, String[]> env, String jmxUrl) throws IOException {
+        JMXServiceURL target = new JMXServiceURL(jmxUrl);
+        JMXConnector connector = null ;
+        try {
+            connector = JMXConnectorFactory.connect(target, env);
+        } catch (FabricAuthenticationException | SecurityException ex) {
+            username = null;
+            password = null;
+            promptForJmxCredentialsIfNeeded();
+            connector = JMXConnectorFactory.connect(target, env);
+        }
+        return connector;
+    }
+
+    private String stripSlashes(String jvmOptions) {
+        String result = jvmOptions;
+        if (jvmOptions == null) {
+            result = "";
+        }
+        return result.replaceAll("\\\\", "");
+    }
+
+    /**
+     * Prompts the user for username & password.
+     */
+    private void promptForJmxCredentialsIfNeeded() throws IOException {
+        // If the username was not configured via cli, then prompt the user for the values
+        if (username == null || username.isEmpty()) {
+            log.debug("Prompting user for JMX login");
+            username = ShellUtils.readLine(session, "JMX Login for " + container + ": ", false);
+        }
+
+        if (password == null) {
+            password = ShellUtils.readLine(session, "JMX Password for " + username + "@" + container + ": ", true);
+        }
+    }
+
+}


### PR DESCRIPTION
Sample usage:

```

Fabric8:karaf@root> container-edit-jvm-options --help

DESCRIPTION
        fabric:container-edit-jvm-options

    Get or set the configured JVM options for a specific container

SYNTAX
        fabric:container-edit-jvm-options [options] containerName [jvmOptions] 

ARGUMENTS
        containerName
                The name of the container.
        jvmOptions
                The default JVM options to use, or empty to show current.

OPTIONS
        -u, --username
                Remote user name
        --help
                Display this help message
        -p, --password
                Remote user password


Fabric8:karaf@root> container-edit-jvm-options child 

-Dcom.sun.management.jmxremote -Dorg.jboss.gravia.repository.storage.dir=data/repository -Dzookeeper.url=192.168.1.132:2181 -Dzookeeper.password.encode=true -Dzookeeper.password=ZKENC=YWRtaW4= -Xmx512m -XX:MaxPermSize=256m -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass -Dio.fabric8.datastore.gitPushInterval=60000 -Dio.fabric8.datastore.component.name=io.fabric8.datastore -Dio.fabric8.datastore.importDir=fabric -Dio.fabric8.datastore.felix.fileinstall.filename=file:/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/etc/io.fabric8.datastore.cfg -Dio.fabric8.datastore.service.pid=io.fabric8.datastore -Densemble.auto.start=true -Densemble.auto.start=true -Djava.util.logging.config.file=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child/etc/java.util.logging.properties -Djava.endorsed.dirs=/usr/java/jdk1.7.0_51/jre/jre/lib/endorsed:/usr/java/jdk1.7.0_51/jre/lib/endorsed:/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/lib/endorsed -Djava.ext.dirs=/usr/java/jdk1.7.0_51/jre/jre/lib/ext:/usr/java/jdk1.7.0_51/jre/lib/ext:/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/lib/ext -Dkaraf.home=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT -Dkaraf.base=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child -Dkaraf.data=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child/data -Dkaraf.etc=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child/etc -Dkaraf.startLocalConsole=false -Dkaraf.startRemoteShell=true



Fabric8:karaf@root> container-edit-jvm-options child  '-XX:NewRatio=9 -Dcom.sun.management.jmxremote -Dorg.jboss.gravia.repository.storage.dir=data/repository -Dzookeeper.url=192.168.1.132:2181 -Dzookeeper.password.encode=true -Dzookeeper.password=ZKENC=YWRtaW4= -Xmx512m -XX:MaxPermSize=256m -XX:+UnlockDiagnosticVMOptions -XX:+UnsyncloadClass -Dio.fabric8.datastore.gitPushInterval=60000 -Dio.fabric8.datastore.component.name=io.fabric8.datastore -Dio.fabric8.datastore.importDir=fabric -Dio.fabric8.datastore.felix.fileinstall.filename=file:/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/etc/io.fabric8.datastore.cfg -Dio.fabric8.datastore.service.pid=io.fabric8.datastore -Densemble.auto.start=true -Densemble.auto.start=true -Djava.util.logging.config.file=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child/etc/java.util.logging.properties -Djava.endorsed.dirs=/usr/java/jdk1.7.0_51/jre/jre/lib/endorsed:/usr/java/jdk1.7.0_51/jre/lib/endorsed:/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/lib/endorsed -Djava.ext.dirs=/usr/java/jdk1.7.0_51/jre/jre/lib/ext:/usr/java/jdk1.7.0_51/jre/lib/ext:/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/lib/ext -Dkaraf.home=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT -Dkaraf.base=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child -Dkaraf.data=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child/data -Dkaraf.etc=/data/repositories/github/fuse/fabric8/fabric8/fabric/fabric8-karaf/target/fabric8-karaf-1.2.0-SNAPSHOT/instances/child/etc -Dkaraf.startLocalConsole=false -Dkaraf.startRemoteShell=true'

Operation succeeded. New JVM flags will be loaded at the next start of child container
```
