### PR TITLE
Fixed UnsupportedOperationException in ProjectDeployer

### DIFF
--- a/fabric/fabric-project-deployer/src/main/java/io/fabric8/deployer/ProjectDeployerImpl.java
+++ b/fabric/fabric-project-deployer/src/main/java/io/fabric8/deployer/ProjectDeployerImpl.java
@@ -180,7 +180,7 @@ public final class ProjectDeployerImpl extends AbstractComponent implements Proj
      * Removes any old parents / features / repos and adds any new parents / features / repos to the profile
      */
     private void updateProfileConfiguration(Version version, Profile profile, ProjectRequirements requirements, ProjectRequirements oldRequirements, ProfileBuilder builder) {
-        List<String> parentProfiles = profile.getParentIds();
+        List<String> parentProfiles = Lists.mutableList(profile.getParentIds());
         List<String> bundles = Lists.mutableList(profile.getBundles());
         List<String> features = Lists.mutableList(profile.getFeatures());
         List<String> repositories = Lists.mutableList(profile.getRepositories());


### PR DESCRIPTION
Hi,

As the `parentProfiles` reference is passed to the `addAll` method, we should wrap the `profile.getParentIds()` results into the mutable collection.

As default `profile.getParentIds()` result is immutable, `ProjectDeployerImpl` throws `UnsupportedOperationException` in `addAll()` when adding new profile via `mvn fabric8:deploy`.

Fixed by making `parentProfiles` mutable.

Cheers.
