### PR TITLE
Git external repo fixes...

### DIFF
--- a/fabric/fabric-api/src/main/java/io/fabric8/api/Constants.java
+++ b/fabric/fabric-api/src/main/java/io/fabric8/api/Constants.java
@@ -25,6 +25,7 @@ public interface Constants {
     String DATASTORE_PID = "io.fabric8.datastore";
     String ZOOKEEPER_CLIENT_PID = "io.fabric8.zookeeper";
     String ZOOKEEPER_SERVER_PID = "io.fabric8.zookeeper.server";
+    String GIT_REMOTE_URL = "gitRemoteUrl";
 
     /**
      * The PID of the system properties used for the Java Container

--- a/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/CreateAction.java
+++ b/fabric/fabric-boot-commands/src/main/java/io/fabric8/boot/commands/CreateAction.java
@@ -15,14 +15,7 @@
  */
 package io.fabric8.boot.commands;
 
-import io.fabric8.api.ContainerOptions;
-import io.fabric8.api.CreateEnsembleOptions;
-import io.fabric8.api.FabricService;
-import io.fabric8.api.RuntimeProperties;
-import io.fabric8.api.ServiceProxy;
-import io.fabric8.api.ZkDefs;
-import io.fabric8.api.ZooKeeperClusterBootstrap;
-import io.fabric8.api.ZooKeeperClusterService;
+import io.fabric8.api.*;
 import io.fabric8.utils.PasswordEncoder;
 import io.fabric8.utils.Ports;
 import io.fabric8.utils.shell.ShellUtils;
@@ -52,7 +45,7 @@ import com.google.common.base.Strings;
 @Command(name = "create", scope = "fabric", description = "Creates a new fabric ensemble (ZooKeeper ensemble)", detailedDescription = "classpath:create.txt")
 class CreateAction extends AbstractAction {
 
-    private static final String GIT_REMOTE_URL = "gitRemoteUrl";
+    private static final String GIT_REMOTE_URL = Constants.GIT_REMOTE_URL;
     private static final String GIT_REMOTE_USER = "gitRemoteUser";
     private static final String GIT_REMOTE_PASSWORD = "gitRemotePassword";
 

--- a/fabric/fabric8-karaf/src/main/resources/etc/io.fabric8.datastore.cfg
+++ b/fabric/fabric8-karaf/src/main/resources/etc/io.fabric8.datastore.cfg
@@ -17,7 +17,7 @@
 # how frequently in milliseconds should we push to the master git repo
 # using a background job that checks for any manual changes in the local
 # git reposiroy that users may push outside from fabric itself.
-gitPushInterval = 60000
+gitRemotePollInterval = 60000
 
 # example of configuring an extenral git repository (a non fabric managed).
 #gitRemoteUrl=https://github.com/<some user>/<some repo>.git

--- a/itests/smoke/embedded/src/test/java/io/fabric8/itests/smoke/embedded/RemoteGitRepositoryTest.java
+++ b/itests/smoke/embedded/src/test/java/io/fabric8/itests/smoke/embedded/RemoteGitRepositoryTest.java
@@ -115,13 +115,13 @@ public class RemoteGitRepositoryTest {
         ConfigurationAdmin configAdmin = ServiceLocator.getRequiredService(ConfigurationAdmin.class);
         Configuration config = configAdmin.getConfiguration(Constants.DATASTORE_PID);
         Dictionary<String, Object> properties = config.getProperties();
-        properties.put("configuredUrl", remoteUrl.toExternalForm());
+        properties.put(Constants.GIT_REMOTE_URL, remoteUrl.toExternalForm());
         config.update(properties);
         
         // Wait for the configuredUrl to show up the {@link ProfileRegistry}
         ProfileRegistry profileRegistry = ServiceLocator.awaitService(ProfileRegistry.class);
         Map<String, String> dsprops = profileRegistry.getDataStoreProperties();
-        while (!dsprops.containsKey("configuredUrl")) {
+        while (!dsprops.containsKey(Constants.GIT_REMOTE_URL)) {
             Thread.sleep(200);
             profileRegistry = ServiceLocator.awaitService(ProfileRegistry.class);
             dsprops = profileRegistry.getDataStoreProperties();
@@ -133,13 +133,13 @@ public class RemoteGitRepositoryTest {
         ConfigurationAdmin configAdmin = ServiceLocator.getRequiredService(ConfigurationAdmin.class);
         Configuration config = configAdmin.getConfiguration(Constants.DATASTORE_PID);
         Dictionary<String, Object> properties = config.getProperties();
-        properties.remove("configuredUrl");
+        properties.remove(Constants.GIT_REMOTE_URL);
         config.update(properties);
         
         // Wait for the configuredUrl to be removed from the {@link ProfileRegistry}
         ProfileRegistry profileRegistry = ServiceLocator.awaitService(ProfileRegistry.class);
         Map<String, String> dsprops = profileRegistry.getDataStoreProperties();
-        while (dsprops.containsKey("configuredUrl")) {
+        while (dsprops.containsKey(Constants.GIT_REMOTE_URL)) {
             Thread.sleep(200);
             profileRegistry = ServiceLocator.awaitService(ProfileRegistry.class);
             dsprops = profileRegistry.getDataStoreProperties();


### PR DESCRIPTION
- re-enabled polling logic in case of git external repo
- unified configuration constants.
- fixes #2514 

@iocanel and @tdiesler  can you give it a quick look?
**ITests are ok** and I have manually tested with and without an **external Github repo**. It **worked fine** in my case.

Th reason why I have renamed the `configuredUrl` in https://github.com/paoloantinori/fabric8/blob/48e5085d16e44f478391dfad029b22287fd3bbd6/fabric/fabric-git/src/main/java/io/fabric8/git/internal/GitDataStoreImpl.java was just to unify with the `pid` property and because `@Property` annotation didn't allow me to have different keys for the variable name and the `name` attribute.
