### PR TITLE
closes #2387

### DIFF
--- a/fab/tests/fab-itests/pom.xml
+++ b/fab/tests/fab-itests/pom.xml
@@ -221,11 +221,6 @@
       </dependency>
       <dependency>
           <groupId>org.ops4j.pax.swissbox</groupId>
-          <artifactId>pax-swissbox-optional-jcl</artifactId>
-          <version>${ops4j-pax-swissbox-optional-jcl.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>org.ops4j.pax.swissbox</groupId>
           <artifactId>pax-swissbox-property</artifactId>
           <version>${ops4j-pax-swissbox-property.version}</version>
       </dependency>

--- a/fab/tests/fab-itests/src/test/java/io/fabric8/fab/osgi/itests/FabIntegrationTestSupport.java
+++ b/fab/tests/fab-itests/src/test/java/io/fabric8/fab/osgi/itests/FabIntegrationTestSupport.java
@@ -117,7 +117,6 @@ public abstract class FabIntegrationTestSupport {
             mavenBundle("org.ops4j.base", "ops4j-base-lang").versionAsInProject(),
             mavenBundle("org.ops4j.base", "ops4j-base-net").versionAsInProject(),
             mavenBundle("org.ops4j.base", "ops4j-base-util-property").versionAsInProject(),
-            mavenBundle("org.ops4j.pax.swissbox", "pax-swissbox-optional-jcl").versionAsInProject(),
             mavenBundle("org.ops4j.pax.swissbox", "pax-swissbox-property").versionAsInProject(),
 
             mavenBundle("io.fabric8", "common-util").versionAsInProject(),

--- a/fabric/fabric-agent/pom.xml
+++ b/fabric/fabric-agent/pom.xml
@@ -410,12 +410,6 @@
             <version>${ops4j-base.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.ops4j.pax.swissbox</groupId>
-            <artifactId>pax-swissbox-optional-jcl</artifactId>
-            <version>${ops4j-pax-swissbox-optional-jcl.version}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.ops4j.pax.url</groupId>

--- a/fabric/fabric-karaf-overlay/src/main/resources/distro/fabric-features.xml
+++ b/fabric/fabric-karaf-overlay/src/main/resources/distro/fabric-features.xml
@@ -87,7 +87,6 @@
         <bundle>mvn:org.ops4j.base/ops4j-base-lang/${ops4j-base.version}</bundle>
         <bundle>mvn:org.ops4j.base/ops4j-base-monitors/${ops4j-base.version}</bundle>
         <bundle>mvn:org.ops4j.base/ops4j-base-util-property/${ops4j-base.version}</bundle>
-        <bundle>mvn:org.ops4j.pax.swissbox/pax-swissbox-optional-jcl/${ops4j-pax-swissbox-optional-jcl.version}</bundle>
         <bundle>mvn:org.ops4j.pax.swissbox/pax-swissbox-property/${ops4j-pax-swissbox-property.version}</bundle>
     </feature>
 

--- a/insight/insight-log4j/src/test/java/io/fabric8/insight/log/log4j/SourceTest.java
+++ b/insight/insight-log4j/src/test/java/io/fabric8/insight/log/log4j/SourceTest.java
@@ -45,7 +45,7 @@ public class SourceTest {
         assertSourceContains(mavenCoords, "org.apache.camel.CamelContext", "", expectedContent);
 
         // now lets try a space separated version
-        String paxCoords = "org.ops4j.base:ops4j-base-lang:1.2.3 org.ops4j.base:ops4j-base-util-collections:1.2.3 org.ops4j.base:ops4j-base-util-property:1.2.3 org.ops4j.base:ops4j-base-util-xml:1.2.3 org.ops4j.pax.swissbox:pax-swissbox-core:1.4.0 org.ops4j.pax.swissbox:pax-swissbox-lifecycle:1.4.0 org.ops4j.pax.swissbox:pax-swissbox-optional-jcl:1.4.0 org.ops4j.pax.swissbox:pax-swissbox-property:1.4.0 org.ops4j.pax.web:pax-web-api:1.1.11 org.ops4j.pax.web:pax-web-runtime:1.1.11 org.ops4j.pax.web:pax-web-spi:1.1.11";
+        String paxCoords = "org.ops4j.base:ops4j-base-lang:1.2.3 org.ops4j.base:ops4j-base-util-collections:1.2.3 org.ops4j.base:ops4j-base-util-property:1.2.3 org.ops4j.base:ops4j-base-util-xml:1.2.3 org.ops4j.pax.swissbox:pax-swissbox-core:1.4.0 org.ops4j.pax.swissbox:pax-swissbox-lifecycle:1.4.0 org.ops4j.pax.swissbox:pax-swissbox-property:1.4.0 org.ops4j.pax.web:pax-web-api:1.1.11 org.ops4j.pax.web:pax-web-runtime:1.1.11 org.ops4j.pax.web:pax-web-spi:1.1.11";
 
         String content = assertSourceContains(paxCoords, "org.ops4j.pax.web.service.internal.HttpServiceFactoryImpl", "HttpServiceFactoryImpl.java", "HttpServiceFactoryImpl");
         //System.out.println(content);

--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,6 @@
         <ops4j-base.version>1.4.0</ops4j-base.version>
         <ops4j-pax-exam-version>3.4.0</ops4j-pax-exam-version>
         <ops4j-pax-swissbox-bnd.version>1.7.1</ops4j-pax-swissbox-bnd.version>
-        <ops4j-pax-swissbox-optional-jcl.version>1.7.1</ops4j-pax-swissbox-optional-jcl.version>
         <ops4j-pax-swissbox-property.version>1.7.1</ops4j-pax-swissbox-property.version>
         <ops4j-pax-url-commons-version>3.4.0</ops4j-pax-url-commons-version>
         <ops4j-pax-web-version>3.1.2</ops4j-pax-web-version>


### PR DESCRIPTION
removing pax-swissbox-optional-jcl, as it is no longer needed and can cause problems with logging import resolution
