### PR TITLE
issue 2667-Improve REST API URL consistency for container/containers

### DIFF
--- a/fabric/fabric-docker-api/src/main/java/io/fabric8/docker/api/Docker.java
+++ b/fabric/fabric-docker-api/src/main/java/io/fabric8/docker/api/Docker.java
@@ -83,7 +83,7 @@ public interface Docker {
 
 
     @GET
-    @Path("/containers/{id}/json")
+    @Path("/container/{id}/json")
     ContainerInfo containerInspect(@PathParam(ID) String id);
 
     /**
@@ -93,35 +93,35 @@ public interface Docker {
      * @return
      */
     @POST
-    @Path("/containers/create")
+    @Path("/container/create")
     ContainerCreateStatus containerCreate(ContainerConfig config, @QueryParam("name") String name);
 
     @GET
-    @Path("/containers/{id}/top")
+    @Path("/container/{id}/top")
     Top containerTop(@PathParam(ID) String id);
 
     @GET
-    @Path("/containers/{id}/changes")
+    @Path("/container/{id}/changes")
     List<Change> containerChanges(@PathParam(ID) String id);
 
     @GET
-    @Path("/containers/{id}/export")
+    @Path("/container/{id}/export")
     byte[] containerExport(@PathParam(ID) String id);
 
     @POST
-    @Path("/containers/{id}/start")
+    @Path("/container/{id}/start")
     void containerStart(@PathParam(ID) String id, HostConfig hostHostConfig);
 
     @POST
-    @Path("/containers/{id}/stop")
+    @Path("/container/{id}/stop")
     void containerStop(@PathParam(ID) String id, @QueryParam("t") Integer timeToWait);
 
     @POST
-    @Path("/containers/{id}/restart")
+    @Path("/container/{id}/restart")
     void containerRestart(@PathParam(ID) String id, @QueryParam("t") Integer timeToWait);
 
     @POST
-    @Path("/containers/{id}/kill")
+    @Path("/container/{id}/kill")
     void containerKill(@PathParam(ID) String id);
 
     /**
@@ -134,12 +134,12 @@ public interface Docker {
      * @param id
      */
     @POST
-    @Path("/containers/{id}/attach")
+    @Path("/container/{id}/attach")
     byte[] containerRestart(@PathParam(ID) String id, @QueryParam("logs") Integer logs, @QueryParam("stream") Integer stream, @QueryParam("stdin") Integer stdin, @QueryParam("stdout") Integer stdout, @QueryParam("stderr") Integer stderr);
 
 
     @POST
-    @Path("/containers/{id}/wait")
+    @Path("/container/{id}/wait")
     Status containerWait(@PathParam(ID) String id);
 
     /**
@@ -150,12 +150,12 @@ public interface Docker {
      * @return
      */
     @DELETE
-    @Path("/containers/{id}")
+    @Path("/container/{id}")
     void containerRemove(@PathParam(ID) String id, @QueryParam("v") Integer v);
 
 
     @POST
-    @Path("/containers/{id}/copy")
+    @Path("/container/{id}/copy")
     byte[] containerCopy(@PathParam(ID) String id, CopySource resource);
 
     /**


### PR DESCRIPTION
I really like this design using HATEOAS because it makes life easier for the developer to find links quickly.

Anyway I'd like to dive in here and patch this up. I've made a fix but doing a grep I noticed that there are a lot of references to "containers" from other classes and docs. The api is already utilizing HATEOAS could I get some clarification on which links are missing?

git grep --files-without-match "\/containers" | grep -e "java$" |uniq | grep -ne "java$"
