### PR TITLE
#2722: FabricManager JMX - fixed getProfiles with list of fields to only...

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
 ### 1.2.0.Beta5
 
 * Profile name must be in lower-case letters
+* Fixed CPU spike when using hawtio and browsing container or profile details
+* Switched to using Apache Karaf 2.4.0
 
 ### 1.2.0.Beta4
 

--- a/fabric/fabric-core/src/main/java/io/fabric8/core/jmx/FabricManager.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/core/jmx/FabricManager.java
@@ -860,7 +860,7 @@ public final class FabricManager implements FabricManagerMBean {
     }
 
     public Map<String, Object> getProfile(String versionId, String profileId, List<String> fields) {
-        return doGetProfile(versionId, profileId, BeanUtils.getFields(Profile.class), true);
+        return doGetProfile(versionId, profileId, fields, true);
     }
 
     Map<String, Object> doGetProfile(String versionId, String profileId, List<String> fields, boolean mandatory) {


### PR DESCRIPTION
... return those fields, and not all of them. This reduces the data returned when using hawtio etc.
