### PR TITLE
Remove container from registry when provider fails

### DIFF
--- a/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
+++ b/fabric/fabric-core/src/main/java/io/fabric8/service/FabricServiceImpl.java
@@ -562,8 +562,8 @@ public final class FabricServiceImpl extends AbstractComponent implements Fabric
                                 metadata.setContainer(container);
                                 LOGGER.info("The container " + metadata.getContainerName() + " has been successfully created");
                             } else {
-                                dataStore.get().deleteContainer(fabricService, containerOptions.getName());
                                 LOGGER.warn("The creation of the container " + metadata.getContainerName() + " has failed", metadata.getFailure());
+                                dataStore.get().deleteContainer(fabricService, containerOptions.getName());
                             }
                             metadatas.add(metadata);
                         } catch (Throwable t) {


### PR DESCRIPTION
When container provider fails failure is added to metadata, but container is not removed from registy, this causes zombie-container to show on container list - e.g. https://github.com/fabric8io/fabric8/issues/2760
