### PR TITLE
Mule restart and addon lib fixes

### DIFF
--- a/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/mule.ce.profile/controller.json
+++ b/fabric/fabric8-karaf/src/main/resources/distro/fabric/import/fabric/profiles/containers/mule.ce.profile/controller.json
@@ -3,5 +3,5 @@
     "pidFile": "bin/.mule.pid",
     "stopCommand": "stop",
     "deployPath": "apps",
-    "sharedLibraryPath": "lib"
+    "sharedLibraryPath": "lib/user"
 }


### PR DESCRIPTION
These changes are necessary to put addon libs in the correct place and to restart mule containers smoothly when profiles are updated.
