### PR TITLE
exclude bad dependency which tends to break docker java containers

### DIFF
--- a/components/fabric-cxf-plugins/pom.xml
+++ b/components/fabric-cxf-plugins/pom.xml
@@ -82,6 +82,13 @@
         <groupId>com.wordnik</groupId>
         <artifactId>swagger-jaxrs_2.10</artifactId>
         <version>1.3.0</version>
+        <exclusions>
+          <!-- avoid this old dependency which breaks CXF -->
+          <exclusion>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>jsr311-api</artifactId>
+          </exclusion>
+        </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
exclude bad dependency which tends to break docker java containers
