### PR TITLE
improve the helper code for extracting properties from maven so we can do more flexible key transformations (e.g. for labels in kube versus env vars)

### DIFF
--- a/components/fabric-utils/src/main/java/io/fabric8/utils/Functions.java
+++ b/components/fabric-utils/src/main/java/io/fabric8/utils/Functions.java
@@ -20,6 +20,11 @@ public class Functions {
     public static Function<String, String> chopLength(final int maxLen) {
         return new Function<String, String>() {
             @Override
+            public String toString() {
+                return "chopLength(" + maxLen + ")";
+            }
+
+            @Override
             public String apply(String value) {
                 if (value == null) {
                     return null;
@@ -27,6 +32,20 @@ public class Functions {
                 if (value.length() > maxLen) {
                     return value.substring(0, maxLen);
                 }
+                return value;
+            }
+        };
+    }
+
+    public static <T> Function<T,T> noop() {
+        return new Function<T,T>() {
+            @Override
+            public String toString() {
+                return "noopFunction()";
+            }
+
+            @Override
+            public T apply(T value) {
                 return value;
             }
         };

--- a/components/fabric-utils/src/main/java/io/fabric8/utils/PropertiesHelper.java
+++ b/components/fabric-utils/src/main/java/io/fabric8/utils/PropertiesHelper.java
@@ -50,9 +50,19 @@ public class PropertiesHelper {
 
     /**
      * Returns the map of entries in the properties object which have keys starting with the given prefix, removing the prefix
-     * from the returned map.   Keys are made lowercase as required by Kubernetes.
+     * from the returned map.
      */
     public static Map<String, String> findPropertiesWithPrefix(Properties properties, String prefix) {
+        return findPropertiesWithPrefix(properties, prefix, Functions.<String>noop());
+    }
+
+    /**
+     * Returns the map of entries in the properties object which have keys starting with the given prefix, removing the prefix
+     * from the returned map.
+     *
+     * Keys are also transformed using the given keyTransformer if specified.
+     */
+    public static Map<String, String> findPropertiesWithPrefix(Properties properties, String prefix, Function<String,String> keyTransformer) {
         Map<String, String> answer = new HashMap<>();
         Set<Map.Entry<Object, Object>> entries = properties.entrySet();
         for (Map.Entry<Object, Object> entry : entries) {
@@ -61,7 +71,10 @@ public class PropertiesHelper {
             if (key instanceof String && value != null) {
                 String keyText = key.toString();
                 if (keyText.startsWith(prefix)) {
-                    String newKey = keyText.substring(prefix.length()).toLowerCase();
+                    String newKey = keyText.substring(prefix.length());
+                    if (keyTransformer != null) {
+                        newKey = keyTransformer.apply(newKey);
+                    }
                     answer.put(newKey, value.toString());
                 }
             }

--- a/components/fabric-utils/src/main/java/io/fabric8/utils/Strings.java
+++ b/components/fabric-utils/src/main/java/io/fabric8/utils/Strings.java
@@ -50,6 +50,7 @@ public class Strings {
         return notEmpty(value) ? value : defaultValue;
     }
 
+
     /**
      * splits a string into a list of strings, ignoring the empty string
      */
@@ -318,4 +319,63 @@ public class Strings {
             }
             return buffer.toString();
         }
+
+
+    // String based functions
+
+
+    public static Function<String, String> toLowerCaseFunction() {
+        return new Function<String, String>() {
+            @Override
+            public String toString() {
+                return "toLowerCaseFunction()";
+            }
+
+            @Override
+            public String apply(String value) {
+                if (value != null) {
+                    return value.toLowerCase();
+                }
+                return null;
+            }
+        };
+    }
+
+    public static Function<String, String> toUpperCaseFunction() {
+        return new Function<String, String>() {
+            @Override
+            public String toString() {
+                return "toUpperCaseFunction()";
+            }
+
+            @Override
+            public String apply(String value) {
+                if (value != null) {
+                    return value.toUpperCase();
+                }
+                return null;
+            }
+        };
+    }
+
+    /**
+     * Converts a string to a valid environment variable by removing bad characters like '.' and ' '
+     */
+    public static Function<String, String> toEnvironmentVariableFunction() {
+        return new Function<String, String>() {
+            @Override
+            public String toString() {
+                return "toEnvironmentVariableFunction()";
+            }
+
+            @Override
+            public String apply(String key) {
+                if (key != null) {
+                    // lets replace any dots in the env var name
+                    return key.replace('.', '_').replace(' ', '_');
+                }
+                return null;
+            }
+        };
+    }
 }

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
@@ -17,6 +17,7 @@ package io.fabric8.maven;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.utils.Files;
+import io.fabric8.utils.Function;
 import io.fabric8.utils.Lists;
 import io.fabric8.utils.Strings;
 import io.fabric8.kubernetes.api.KubernetesHelper;
@@ -410,7 +411,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
             labels = new HashMap<>();
         }
         if (labels.isEmpty()) {
-            labels = findPropertiesWithPrefix(getProject().getProperties(), "fabric8.label.");
+            labels = findPropertiesWithPrefix(getProject().getProperties(), "fabric8.label.", Strings.toLowerCaseFunction());
         }
         return labels;
     }
@@ -421,7 +422,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
         }
         if (environmentVariables.isEmpty()) {
             Map<String, Env> envMap = new HashMap<>();
-            Map<String, String> envs = findPropertiesWithPrefix(getProject().getProperties(), "fabric8.env.");
+            Map<String, String> envs = findPropertiesWithPrefix(getProject().getProperties(), "fabric8.env.", Strings.toEnvironmentVariableFunction());
 
             for (Map.Entry<String, String> entry : envs.entrySet()) {
                 String name = entry.getKey();


### PR DESCRIPTION
improve the helper code for extracting properties from maven so we can do more flexible key transformations (e.g. for labels in kube versus env vars)
