### PR TITLE
Fixes #3322: Use kubernetes RO service for RO ops, writeable for changes

### DIFF
--- a/components/console/pom.xml
+++ b/components/console/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <blueprint-web-version>1.0.0</blueprint-web-version>
-    <fabric8.release.version>2.0.8</fabric8.release.version>
+    <fabric8.release.version>2.0.19</fabric8.release.version>
   </properties>
 
   <dependencies>

--- a/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/Example.java
+++ b/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/Example.java
@@ -42,7 +42,7 @@ import static io.fabric8.kubernetes.api.KubernetesHelper.getSelector;
  */
 public class Example {
     public static void main(String... args) {
-        KubernetesFactory kubeFactory = new KubernetesFactory();
+        KubernetesFactory kubeFactory = new KubernetesFactory(true);
         if (args.length > 0) {
             kubeFactory.setAddress(args[0]);
         }

--- a/forge-addons/camel/pom.xml
+++ b/forge-addons/camel/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.fabric8.forge</groupId>
     <artifactId>forge-addons</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.2-SNAPSHOT</version>
   </parent>
   <artifactId>camel</artifactId>
   <name>Fabric8 :: Forge Addons :: Camel</name>


### PR DESCRIPTION
- Use kubernetes RO service for RO operations, writeable service only for writeable ops
- Validate server address
- Default writeable to https, fallback to http if https is unavailable