### PR TITLE
Added index to Mutable response obj as jackson complains if missing

### DIFF
--- a/components/fabric-etcd/core/src/main/java/io/fabric8/etcd/core/MutableResponse.java
+++ b/components/fabric-etcd/core/src/main/java/io/fabric8/etcd/core/MutableResponse.java
@@ -27,6 +27,15 @@ public class MutableResponse implements Response<MutableNode> {
     public String message;
     public String cause;
     public int errorIndex;
+    public int index;
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
 
     public String getAction() {
         return action;

--- a/components/fabric-etcd/itests/pom.xml
+++ b/components/fabric-etcd/itests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>fabric-etcd</artifactId>
         <groupId>io.fabric8</groupId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8.etcd.reader</groupId>
-            <artifactId>fabric-etcd-reader-gson</artifactId>
+            <artifactId>fabric-etcd-reader-jackson</artifactId>
         </dependency>
 
         <!-- Testing dependencies -->

--- a/components/fabric-etcd/itests/src/test/java/io/fabric8/etcd/itests/SmokeTest.java
+++ b/components/fabric-etcd/itests/src/test/java/io/fabric8/etcd/itests/SmokeTest.java
@@ -20,7 +20,7 @@ import io.fabric8.etcd.api.EtcdClient;
 import io.fabric8.etcd.api.EtcdException;
 import io.fabric8.etcd.api.Response;
 import io.fabric8.etcd.core.EtcdClientImpl;
-import io.fabric8.etcd.reader.gson.GsonResponseReader;
+import io.fabric8.etcd.reader.jackson.JacksonResponseReader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,8 +40,8 @@ public class SmokeTest {
 
     @Before
     public void setUp() throws URISyntaxException {
-        String url = System.getProperty("etcd.url");
-        client = new EtcdClientImpl.Builder().baseUri(new URI(url)).responseReader(new GsonResponseReader()).build();
+        String url ="http://127.0.0.1:4001/v2/"; //System.getProperty("etcd.url");
+        client = new EtcdClientImpl.Builder().baseUri(new URI(url)).responseReader(new JacksonResponseReader()).build();
         client.start();
         try {
             client.delete().dir().recursive().forKey("key");

--- a/components/fabric-etcd/pom.xml
+++ b/components/fabric-etcd/pom.xml
@@ -34,7 +34,6 @@
         <module>api</module>
         <module>core</module>
         <module>reader</module>
-        <module>itests</module>
     </modules>
 
     <profiles>

--- a/components/fabric-etcd/pom.xml
+++ b/components/fabric-etcd/pom.xml
@@ -34,6 +34,7 @@
         <module>api</module>
         <module>core</module>
         <module>reader</module>
+        <module>itests</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Changes:
* Added itests module to fabric-etcd parent pom (in order to run the tests - should be removed again, I suppose)
* Corrected parent pom reference in fabric-etcd-itests
* Changed from gson to jackson in fabric-etcd-itests pom and in SmokeTest
* **Main change**: Tests would fail, if I did not also add the **index field in MutableResponse**

Test error without the index field:

    -------------------------------------------------------------------------------
    Test set: io.fabric8.etcd.itests.SmokeTest
    -------------------------------------------------------------------------------
    Tests run: 10, Failures: 0, Errors: 10, Skipped: 0, Time elapsed: 0.496 sec <<< FAILURE! - in io.fabric8.etcd.itests.SmokeTest
    testSetGetAndDelete(io.fabric8.etcd.itests.SmokeTest)  Time elapsed: 0.437 sec  <<< ERROR!
    java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "index" (class io.fabric8.etcd.core.MutableResponse), not marked as ignorable (7 known properties: "node", "prevNode", "errorCode", "action", "message", "cause", "errorIndex"])
     at [Source: org.apache.http.nio.entity.ContentInputStream@38c5cc4c; line: 1, column: 70] (through reference chain: io.fabric8.etcd.core.MutableResponse["index"])
        at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:51)
        at com.fasterxml.jackson.databind.DeserializationContext.reportUnknownProperty(DeserializationContext.java:731)
        at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:915)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1292)
...