### PR TITLE
fixes #3381 so we can disable verification of kube master URLs when working with jube

### DIFF
--- a/components/fabric-utils/src/main/java/io/fabric8/utils/Asserts.java
+++ b/components/fabric-utils/src/main/java/io/fabric8/utils/Asserts.java
@@ -51,6 +51,24 @@ public class Asserts {
         return answer;
     }
 
+    /**
+     * Asserts that the code block throws an {@link AssertionError) and returns it
+     */
+    public static Exception assertException(Block block) throws Exception {
+        Exception answer = null;
+        try {
+            block.invoke();
+        } catch (Exception e) {
+            answer = e;
+            System.out.println("Caught expected assertion failure: " + e);
+        }
+        if (answer == null) {
+            throw new AssertionError("Expected an Exception from block: " + block);
+        }
+        Asserts.LOG.info("Caught expected assertion failure: " + answer);
+        return answer;
+    }
+
 
     /**
      * Asserts that the block passes at some point within the given time period.

--- a/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/UsingBadAddressTest.java
+++ b/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/UsingBadAddressTest.java
@@ -1,0 +1,47 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.api;
+
+import io.fabric8.utils.Asserts;
+import io.fabric8.utils.Block;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ */
+public class UsingBadAddressTest {
+    protected String badAddress = "cheese://does.notexist.redhat.com:666";
+
+    @Test
+    public void testUseBadAddressFails() throws Exception {
+        Asserts.assertException(new Block() {
+            @Override
+            public void invoke() throws Exception {
+                new KubernetesFactory(badAddress);
+            }
+        });
+    }
+
+    @Test
+    public void testUseBadAddressWithoutValidation() throws Exception {
+        KubernetesFactory factory = new KubernetesFactory(badAddress, true, false);
+        assertThat(factory).isNotNull();
+    }
+
+}


### PR DESCRIPTION
fixes #3381 so we can disable verification of kube master URLs when working with jube