### PR TITLE
use a RC ID that doesn't barf in latest openshift

### DIFF
--- a/bin/fabric8.json
+++ b/bin/fabric8.json
@@ -65,7 +65,7 @@
         },
         "replicas": 1
       },
-      "id": "fabric8ConsoleController",
+      "id": "fabric8-console-controller",
       "kind": "ReplicationController",
       "labels": {
         "component": "fabric8ConsoleController"

--- a/components/kubernetes-assertions/src/test/java/io/fabric8/kubernetes/assertions/Example.java
+++ b/components/kubernetes-assertions/src/test/java/io/fabric8/kubernetes/assertions/Example.java
@@ -55,17 +55,17 @@ public class Example {
                 }
             });
 
-            assertThat(client).replicationController("fabric8ConsoleController").hasId("fabric8ConsoleController");
+            assertThat(client).replicationController("fabric8-console-controller").hasId("fabric8-console-controller");
 
             Map<String, String> consoleLabels = new HashMap<>();
             consoleLabels.put("component", "fabric8Console");
 
-            assertThat(client).podsForReplicationController("fabric8ConsoleController").runningStatus().extracting("labels").contains(consoleLabels);
+            assertThat(client).podsForReplicationController("fabric8-console-controller").runningStatus().extracting("labels").contains(consoleLabels);
 
             assertAssertionError(new Block() {
                 @Override
                 public void invoke() throws Exception {
-                    assertThat(client).replicationController("doesNotExist").hasId("fabric8ConsoleController");
+                    assertThat(client).replicationController("doesNotExist").hasId("fabric8-console-controller");
                 }
             });
 


### PR DESCRIPTION
use a RC ID that doesn't barf in latest openshift