### PR TITLE
fixes #3428 so we can easily auto generate a json schema file for any jar which has CDI based environment variables injected via @ConfigProperty so we can know all the environment variables, their types and default values and description

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -65,4 +65,24 @@
     <module>fabric-apm</module>
   </modules>
 
+  <profiles>
+    <!-- enables the APT dependency so that it can be disabled in IDE builds -->
+    <profile>
+      <id>apt</id>
+      <activation>
+        <property>
+            <name>!dummy.prop.to.keep.this.profile.active.even.when.other.profiles.are.active</name>
+        </property>
+      </activation>
+
+      <dependencies>
+        <!-- enable the APT processor -->
+        <dependency>
+          <groupId>io.fabric8</groupId>
+          <artifactId>fabric8-apt</artifactId>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/components/zookeeper-client/src/main/java/io/fabric8/zookeeper/bootstrap/InjectableQuorumPeerConfig.java
+++ b/components/zookeeper-client/src/main/java/io/fabric8/zookeeper/bootstrap/InjectableQuorumPeerConfig.java
@@ -20,12 +20,23 @@ import org.apache.zookeeper.server.ZooKeeperServer;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 
 import javax.inject.Inject;
+import java.lang.annotation.Documented;
 import java.net.InetSocketAddress;
 
 /**
  * Allows easy injection with CDI for a {@link QuorumPeerConfig}
  */
 public class InjectableQuorumPeerConfig extends QuorumPeerConfig {
+    /**
+     *
+     * @param clientPort the port the ZooKeeper client uses to connect to
+     * @param electionPort the port ZooKeeper uses to perform elections
+     * @param dataDir the directory ZooKeeper uses to store its data
+     * @param dataLogDir  the directory ZooKeeper uses to store its logs
+     * @param tickTime  the keep alive tick time
+     * @param initLimit initialisation limit
+     * @param syncLimit synchronisation limit
+     */
     @Inject
     public InjectableQuorumPeerConfig(@ConfigProperty(name = "ZOOKEEPER_CLIENT_PORT", defaultValue = "2181")
                                       int clientPort,

--- a/fabric8-apt/pom.xml
+++ b/fabric8-apt/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2014 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <groupId>io.fabric8</groupId>
+    <artifactId>fabric8-parent</artifactId>
+    <version>2.2-SNAPSHOT</version>
+    <relativePath>../parent</relativePath>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>fabric8-apt</artifactId>
+  <name>Fabric8 :: APT</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.deltaspike.core</groupId>
+      <artifactId>deltaspike-core-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Disable annotation processing for ourselves -->
+          <proc>none</proc>
+          <verbose>false</verbose>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/fabric8-apt/src/main/java/io/fabric8/tools/apt/AbstractAnnotationProcessor.java
+++ b/fabric8-apt/src/main/java/io/fabric8/tools/apt/AbstractAnnotationProcessor.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tools.apt;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Abstract base class
+ */
+public abstract class AbstractAnnotationProcessor extends AbstractProcessor {
+
+
+    protected static String javaTypeName(Element element) {
+        TypeMirror typeMirror = element.asType();
+        return typeMirror.toString();
+    }
+
+    protected void log(String message) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, message);
+    }
+
+    protected void warning(String message) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, message);
+    }
+
+    protected void error(String message) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message);
+    }
+
+    protected void log(Throwable e) {
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, e.getMessage());
+        StringWriter buffer = new StringWriter();
+        PrintWriter writer = new PrintWriter(buffer);
+        e.printStackTrace(writer);
+        writer.close();
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, buffer.toString());
+    }
+
+    /**
+     * Helper method to produce class output text file using the given handler
+     */
+    protected void writeFile(String packageName, String fileName, String text) {
+        Writer writer = null;
+        try {
+            Writer out;
+            Filer filer = processingEnv.getFiler();
+            FileObject resource;
+            try {
+                resource = filer.getResource(StandardLocation.CLASS_OUTPUT, packageName, fileName);
+            } catch (Throwable e) {
+                resource = filer.createResource(StandardLocation.CLASS_OUTPUT, packageName, fileName);
+            }
+            URI uri = resource.toUri();
+            File file = null;
+            if (uri != null) {
+                try {
+                    file = new File(uri.getPath());
+                } catch (Exception e) {
+                    warning("Could not convert output directory resource URI to a file " + e);
+                }
+            }
+            if (file == null) {
+                warning("No class output directory could be found!");
+            } else {
+                file.getParentFile().mkdirs();
+                log("Generating file " + file);
+                writer = new FileWriter(file);
+                writer.write(text);
+            }
+        } catch (IOException e) {
+            log(e);
+        } finally {
+            IOHelper.close(writer);
+        }
+    }
+
+    public Elements getElements() {
+        Elements elementUtils = null;
+        if (processingEnv != null) {
+            elementUtils = processingEnv.getElementUtils();
+        }
+        return elementUtils;
+    }
+}

--- a/fabric8-apt/src/main/java/io/fabric8/tools/apt/ConfigPropertyAnnotationProcessor.java
+++ b/fabric8-apt/src/main/java/io/fabric8/tools/apt/ConfigPropertyAnnotationProcessor.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tools.apt;
+
+import org.apache.deltaspike.core.api.config.ConfigProperty;
+
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import java.util.Set;
+
+/**
+ * Processes all Camel {@link ConfigProperty}s and generate json schema and html documentation for the endpoint/component.
+ */
+@SupportedAnnotationTypes({"*"})
+@SupportedSourceVersion(SourceVersion.RELEASE_7)
+public class ConfigPropertyAnnotationProcessor extends AbstractAnnotationProcessor {
+
+    public boolean process(Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) {
+            return true;
+        }
+        Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(ConfigProperty.class);
+        if (!elements.isEmpty()) {
+            StringBuilder buffer = new StringBuilder("{");
+            buffer.append("\n  \"type\": \"object\",");
+
+            // TODO add schema, title, description from env...
+            log("options: " + processingEnv.getOptions());
+
+            buffer.append("\n  \"properties\": {");
+
+            boolean first = true;
+            for (Element element : elements) {
+                processEndpointClass(roundEnv, element, buffer, first);
+                first = false;
+            }
+            buffer.append("\n  }");
+            buffer.append("\n}");
+            buffer.append("\n");
+
+            String text = buffer.toString();
+            writeFile("io.fabric8.environment", "schema.json", text);
+        }
+        return true;
+    }
+
+    protected void processEndpointClass(final RoundEnvironment roundEnv, final Element element, StringBuilder buffer, boolean first) {
+        final ConfigProperty property = element.getAnnotation(ConfigProperty.class);
+        if (property != null) {
+            String defaultValue = property.defaultValue();
+            if ("org.apache.deltaspike.NullValueMarker".equals(defaultValue)) {
+                defaultValue = null;
+            }
+            String name = property.name();
+
+            String description = JavaDocs.getJavaDoc(getElements(), element);
+            String javaTypeName = javaTypeName(element);
+            String jsonType = JsonSchemaTypes.getJsonSchemaTypeName(javaTypeName);
+
+            if (!first) {
+                buffer.append(",");
+            }
+            buffer.append("\n    \"").append(name).append("\": {");
+            buffer.append("\n      \"type\": \"").append(jsonType).append("\",");
+            if (defaultValue != null) {
+                buffer.append("\n      \"default\": \"").append(defaultValue).append("\",");
+            }
+            if (description != null) {
+                description = description.trim();
+                if (description.length() > 0) {
+                    buffer.append("\n      \"description\": \"").append(description).append("\",");
+                }
+            }
+            buffer.append("\n      \"javaType\": \"").append(javaTypeName).append("\"");
+            buffer.append("\n    }");
+        }
+    }
+}

--- a/fabric8-apt/src/main/java/io/fabric8/tools/apt/IOHelper.java
+++ b/fabric8-apt/src/main/java/io/fabric8/tools/apt/IOHelper.java
@@ -1,0 +1,27 @@
+package io.fabric8.tools.apt;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+final class IOHelper {
+
+    private IOHelper() {
+    }
+
+    /**
+     * Closes the given resources if they are available.
+     *
+     * @param closeables the objects to close
+     */
+    public static void close(Closeable... closeables) {
+        for (Closeable closeable : closeables) {
+            if (closeable != null) {
+                try {
+                    closeable.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+}

--- a/fabric8-apt/src/main/java/io/fabric8/tools/apt/JavaDocs.java
+++ b/fabric8-apt/src/main/java/io/fabric8/tools/apt/JavaDocs.java
@@ -1,0 +1,66 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tools.apt;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.util.Elements;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ */
+public class JavaDocs {
+    /**
+     * Lets search the javadoc for the text "@param parameterName text (@param|@return|@exception)" and extract the text for a parameter name
+     */
+    public static String findParameterJavaDoc(String javadoc, String parameterName) {
+        Pattern regex = Pattern.compile(".*\\s+@param\\s+" + parameterName + "\\s+(.*)");
+        Matcher matcher = regex.matcher(javadoc);
+        if (matcher.find()) {
+            String prefix = matcher.group(1);
+            if (!Strings.isNullOrEmpty(prefix)) {
+                // now lets strip any trailing tags from the end of the text
+                Pattern nextTag = Pattern.compile("\\s+(@param|@return|@exception|@throws|@serialData|@see|@since|@deprecated)");
+                Matcher endMatcher = nextTag.matcher(prefix);
+                if (endMatcher.find()) {
+                    int start = endMatcher.start();
+                    return prefix.substring(0, start).trim();
+                } else {
+                    return prefix;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static String getJavaDoc(Elements elementUtils, Element element) {
+        // TODO folks could maybe use an annotation to document injection parameters rather than messing with javadoc?
+        if (elementUtils != null) {
+            String description = elementUtils.getDocComment(element);
+            if (Strings.isNullOrEmpty(description) && element.getKind() == ElementKind.PARAMETER) {
+                String parentDoc = getJavaDoc(elementUtils, element.getEnclosingElement());
+                if (!Strings.isNullOrEmpty(parentDoc)) {
+                    return findParameterJavaDoc(parentDoc, element.getSimpleName().toString());
+                }
+            }
+            return description;
+        }
+        return  null;
+    }
+}

--- a/fabric8-apt/src/main/java/io/fabric8/tools/apt/JsonSchemaTypes.java
+++ b/fabric8-apt/src/main/java/io/fabric8/tools/apt/JsonSchemaTypes.java
@@ -1,0 +1,52 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tools.apt;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.type.TypeMirror;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Maps Java types to JSON Schema types
+ */
+public class JsonSchemaTypes {
+    protected static Map<String,String> javaToJsonSchemaTypes = new HashMap<>();
+
+    static {
+        addTypeAliases("boolean", Boolean.class.getName(), "boolean");
+        addTypeAliases("integer", Byte.class.getName(), Character.class.getName(),
+                Short.class.getName(), Integer.class.getName(), Long.class.getName(),
+                "byte", "char", "short", "int", "long");
+        addTypeAliases("number", Float.class.getName(), Double.class.getName(), "float", "double");
+        addTypeAliases("string", String.class.getName());
+    }
+
+
+    protected static void addTypeAliases(String jsonSchemaType, String... javaTypeNames) {
+        for (String javaTypeName : javaTypeNames) {
+            javaToJsonSchemaTypes.put(javaTypeName, jsonSchemaType);
+        }
+    }
+
+    public static String getJsonSchemaTypeName(String javaTypeName) {
+        String answer =  javaToJsonSchemaTypes.get(javaTypeName);
+        return answer != null ? answer : javaTypeName;
+    }
+
+}

--- a/fabric8-apt/src/main/java/io/fabric8/tools/apt/Strings.java
+++ b/fabric8-apt/src/main/java/io/fabric8/tools/apt/Strings.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tools.apt;
+
+/**
+ * Some String helper methods
+ */
+final class Strings {
+
+    private Strings() {
+        //Helper class
+    }
+
+    /**
+     * Returns true if the given text is null or empty string or has <tt>null</tt> as the value
+     */
+    public static boolean isNullOrEmpty(String text) {
+        return text == null || text.length() == 0 || "null".equals(text);
+    }
+}

--- a/fabric8-apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/fabric8-apt/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+io.fabric8.tools.apt.ConfigPropertyAnnotationProcessor

--- a/fabric8-apt/src/test/java/io/fabric8/tools/apt/ExtractParameterJavaDocTest.java
+++ b/fabric8-apt/src/test/java/io/fabric8/tools/apt/ExtractParameterJavaDocTest.java
@@ -1,0 +1,42 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.tools.apt;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ */
+public class ExtractParameterJavaDocTest {
+
+    @Test
+    public void testFindingParameterJavaDoc() throws Exception {
+        assertParamJavaDoc("foo", "blah @param foo something here @param another thing", "something here");
+        assertParamJavaDoc("foo", "blah @param foo something here", "something here");
+        assertParamJavaDoc("foo", "blah @param cheese blah @param foo something here @param another thing", "something here");
+        assertParamJavaDoc("foo", "blah @param cheese blah @param foo something here @return", "something here");
+        assertParamJavaDoc("foo", "blah @param cheese blah @param foo something here", "something here");
+    }
+
+    public static  void assertParamJavaDoc(String paramName, String javadoc, String expected) {
+        String actual = JavaDocs.findParameterJavaDoc(javadoc, paramName);
+        assertEquals("javadoc: " + javadoc, expected, actual);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+              <groupId>io.fabric8</groupId>
+              <artifactId>fabric8-apt</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.fabric8</groupId>
                 <artifactId>fabric-cxf</artifactId>
                 <version>${project.version}</version>
@@ -2854,6 +2859,7 @@
     <modules>
         <module>bom</module>
         <module>parent</module>
+        <module>fabric8-apt</module>
         <module>fabric8-maven-plugin</module>
         <module>components</module>
         <module>tooling</module>


### PR DESCRIPTION
fixes #3428 so we can easily auto generate a json schema file for any jar which has CDI based environment variables injected via @ConfigProperty so we can know all the environment variables, their types and default values and description