### PR TITLE
fixes #3429 to reuse any fabric8.env maven properties too to enrich/override the @ConfigProperty values

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/AbstractFabric8Mojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/AbstractFabric8Mojo.java
@@ -177,7 +177,7 @@ public abstract class AbstractFabric8Mojo extends AbstractMojo {
     }
 
     /**
-     * Returns all the environment variable properties defined in the pom.xml
+     * Returns all the environment variable properties defined in the pom.xml which are prefixed with "fabric8.env."
      */
     public Map<String, String> getEnvironmentVariableProperties() {
         return findPropertiesWithPrefix(getProject().getProperties(), "fabric8.env.", Strings.toEnvironmentVariableFunction());

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
@@ -473,6 +473,8 @@ public class JsonMojo extends AbstractFabric8Mojo {
                     }
                     answer.put(name, value);
                 }
+                Map<String, String> mavenEnvVars = getEnvironmentVariableProperties();
+                answer.putAll(mavenEnvVars);
                 return answer;
             } catch (IOException e) {
                 throw new MojoExecutionException("Failed to load environment variable json schema files: " + e, e);


### PR DESCRIPTION
fixes #3429 to reuse any fabric8.env maven properties too to enrich/override the @ConfigProperty values