### PR TITLE
bind port 80 to host port while router creation

### DIFF
--- a/bin/start-openshift-docker.sh
+++ b/bin/start-openshift-docker.sh
@@ -140,7 +140,7 @@ validateService()
 }
 
 validateService "Kubernetes master" $KUBERNETES
-$KUBE_EX router --create --ports=80,443
+$KUBE_EX router --create --ports=80:80,443
 
 if [ ${DEPLOY_ALL} -eq 1 ]; then
   # Have to run it privileged otherwise not working on CentOS7


### PR DESCRIPTION
When using the openshift ex router command the created router should bind to the host port