### PR TITLE
a build is triggered by a single process id so lets avoid the 1-many relationship in the correlator; also lets warn if a second process instance tries to associate itself with an existing build #3671

### DIFF
--- a/components/fabric8-build-workflow/src/main/java/io/fabric8/io/fabric8/workflow/build/correlate/BuildProcessCorrelator.java
+++ b/components/fabric8-build-workflow/src/main/java/io/fabric8/io/fabric8/workflow/build/correlate/BuildProcessCorrelator.java
@@ -35,7 +35,7 @@ public interface BuildProcessCorrelator {
     void putBuildProcessInstanceId(BuildCorrelationKey key, long processInstanceId);
 
     /**
-     * Finds all the jBPM process instance IDs which are related to the given build key
+     * Finds the process instance ID for the given build key
      */
-    List<Long> findProcessInstancesForBuild(BuildCorrelationKey buildKey);
+    Long findProcessInstanceIdForBuild(BuildCorrelationKey buildKey);
 }

--- a/components/fabric8-build-workflow/src/main/java/io/fabric8/io/fabric8/workflow/build/correlate/MemoryBuildProcessCorrelator.java
+++ b/components/fabric8-build-workflow/src/main/java/io/fabric8/io/fabric8/workflow/build/correlate/MemoryBuildProcessCorrelator.java
@@ -18,6 +18,8 @@
 package io.fabric8.io.fabric8.workflow.build.correlate;
 
 import io.fabric8.io.fabric8.workflow.build.BuildCorrelationKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,20 +30,22 @@ import java.util.concurrent.ConcurrentHashMap;
  * A simple in memory implementation for testing.
  */
 public class MemoryBuildProcessCorrelator implements BuildProcessCorrelator {
+    private static final transient Logger LOG = LoggerFactory.getLogger(MemoryBuildProcessCorrelator.class);
+
     private Map<BuildCorrelationKey, Long> map = new ConcurrentHashMap<>();
 
     @Override
     public void putBuildProcessInstanceId(BuildCorrelationKey buildKey, long processInstanceId) {
+        Long oldPid = map.get(buildKey);
+        if (oldPid != null) {
+            LOG.warn("Already associated build key " + buildKey + " with processID: " + oldPid + " so ignoring newer process: " + processInstanceId);
+            return;
+        }
         map.put(buildKey, processInstanceId);
     }
 
     @Override
-    public List<Long> findProcessInstancesForBuild(BuildCorrelationKey buildKey) {
-        List<Long> answer = new ArrayList<>();
-        Long id = map.get(buildKey);
-        if (id != null) {
-            answer.add(id);
-        }
-        return answer;
+    public Long findProcessInstanceIdForBuild(BuildCorrelationKey buildKey) {
+        return map.get(buildKey);
     }
 }

--- a/components/fabric8-build-workflow/src/main/java/io/fabric8/io/fabric8/workflow/build/signal/BuildSignaller.java
+++ b/components/fabric8-build-workflow/src/main/java/io/fabric8/io/fabric8/workflow/build/signal/BuildSignaller.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 //import org.jbpm.ruleflow.core.RuleFlowProcess;
@@ -44,7 +43,6 @@ public class BuildSignaller implements BuildListener {
     private final RuntimeEngine engine;
     private final BuildProcessCorrelator buildProcessCorrelator;
     private final KieSession ksession;
-    private boolean initialised = false;
 
     public BuildSignaller(KieBase kbase, RuntimeEngine engine, BuildProcessCorrelator buildProcessCorrelator) {
         this.kbase = kbase;
@@ -71,17 +69,13 @@ public class BuildSignaller implements BuildListener {
         signalObject.put("buildUuid", buildUuid);
         signalObject.put("buildLink", buildLink);
 
-        List<Long> processIds = buildProcessCorrelator.findProcessInstancesForBuild(key);
-        if (processIds.isEmpty()) {
+        Long processId = buildProcessCorrelator.findProcessInstanceIdForBuild(key);
+        if (processId == null) {
             LOG.info("No existing processes associated with build " + key + " so lets signal a new process to start");
             ksession.signalEvent(buildName, signalObject);
         } else {
-            for (Long processId : processIds) {
-                LOG.info("Signalling event on process id: " + processId + " for " + key + " with data: " + signalObject);
-                ksession.signalEvent(buildName, signalObject, processId);
-            }
+            LOG.info("Signalling event on process id: " + processId + " for " + key + " with data: " + signalObject);
+            ksession.signalEvent(buildName, signalObject, processId);
         }
-
     }
-
 }


### PR DESCRIPTION
a build is triggered by a single process id so lets avoid the 1-many relationship in the correlator; also lets warn if a second process instance tries to associate itself with an existing build #3671