### PR TITLE
disable https from gogs until we get a real cert so we can clone git repos on https from STI and orion

### DIFF
--- a/forge/fabric8-forge-core/src/main/java/io/fabric8/forge/rest/main/GitUserHelper.java
+++ b/forge/fabric8-forge-core/src/main/java/io/fabric8/forge/rest/main/GitUserHelper.java
@@ -38,8 +38,10 @@ public class GitUserHelper {
     private final String gitPassword;
     private String address;
 
+    // TODO it'd be nice to pick either http or https based on the port number of the gogs service
+    // so if folks configured it on https then we'd just work
     @Inject
-    public GitUserHelper(@ServiceName("GOGS_HTTP_SERVICE") @Protocol("https") String gogsUrl,
+    public GitUserHelper(@ServiceName("GOGS_HTTP_SERVICE") @Protocol("http") String gogsUrl,
                          @ConfigProperty(name = "GIT_DEFAULT_USER") String gitUser,
                          @ConfigProperty(name = "GIT_DEFAULT_PASSWORD") String gitPassword) {
         this.gitUser = gitUser;


### PR DESCRIPTION
disable https from gogs until we get a real cert so we can clone git repos on https from STI and orion