### PR TITLE
Fix alias quoting

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,8 +18,8 @@ echo *        soft    nofile           8192 >> /etc/security/limits.conf
 
 # add some user aliases
 echo >> ~/.bashrc
-echo export DOCKER_IP=172.28.128.4 >> ~/.bashrc
-echo alias kube=\"docker run --rm -i --net=host openshift/origin kube\" >> ~/.bashrc
+echo 'export DOCKER_IP=172.28.128.4' >> ~/.bashrc
+echo 'alias kube="docker run --rm -i --net=host openshift/origin kube"' >> ~/.bashrc
 
 SCRIPT
 


### PR DESCRIPTION
Otherwise bash croaks because of missing quotes when doing sudo.

Escaping doesn't work because the HERE string eats up the first escaping level. Double escaping would be necessary, or no escaping at all if put into single quotes :)

(Yippie, first commit, even it's a trivial one ;-)