### PR TITLE
Upgrade apiman to version 1.1.3.CR1 + replace TransportClient with JestClient

### DIFF
--- a/components/gateway-api/src/main/java/io/fabric8/gateway/api/apimanager/ApiManagerService.java
+++ b/components/gateway-api/src/main/java/io/fabric8/gateway/api/apimanager/ApiManagerService.java
@@ -15,9 +15,9 @@
  */
 package io.fabric8.gateway.api.apimanager;
 
-import java.util.Map;
-
 import io.fabric8.gateway.api.handlers.http.HttpGatewayHandler;
+
+import java.util.Map;
 
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.http.HttpClient;
@@ -27,7 +27,7 @@ import org.vertx.java.core.http.HttpServerRequest;
 /**
  * Fabric8's API Manager interface. The interface provides access to a 3rd party 'Engine',
  * as well as access to handler needed for the asynchronous nature of Fabric8's HTTPGateway.
- * The ApiManager 
+ * The ApiManager
  */
 public interface ApiManagerService {
 
@@ -35,38 +35,38 @@ public interface ApiManagerService {
 	public final static String HTTP_GATEWAY = "httpGateway";
 	public final static String PORT         = "port";
 	public final static String PORT_REST    = "port.rest";
-	
+
 	public void init(Map<String,Object> config);
-	
+
 	/** Get a reference to a 3rd Party API Manager Engine */
 	public Object getEngine();
-	
+
 	/**
-     * Creates a Handler of type HttpClientResponse. The HttpGateway knows if it is configured 
+     * Creates a Handler of type HttpClientResponse. The HttpGateway knows if it is configured
      * to run with an API Manager or as a simple proxy. Therefore it can return the correct handler
      * to be registered with the vert.x framework. This handler is called to handle a response
      * from a fabric8 service.
-     * 
+     *
      * @param httpClient - vert.x HttpClient used to call the fabric8 service
      * @param httpServerRequest - vert.x HttpServerRequest used to create a HttpServiceResponseHandler
      *  when no API Manager is used
-     * @param apiManagementResponseHandler -  
+     * @param apiManagementResponseHandler -
      * @return
-     * 
+     *
      * @See       HttpServiceResponseHandler
      * @See ApiManHttpServiceResponseHandler
-     * 
+     *
      */
     public Handler<HttpClientResponse>  createServiceResponseHandler(HttpClient httpClient,
     		Object apiManagementResponseHandler);
 	/**
 	 * Creates an implementation of a Handler of type HttpServerRequest, and returns a reference.
 	 * This handler is called by the vert.x framework, when when the gateway invoked by an external
-	 * client application. 
-	 * 
-	
+	 * client application.
+	 *
+
 	 * @return a Handler of type HttpServerRequest
-	 * 
+	 *
 	 * @see       HttpGatewayHandler
 	 * @see ApiManHttpGatewayHandler
 	 */
@@ -74,9 +74,9 @@ public interface ApiManagerService {
 	/**
 	 * Return service info: OrganizationId, ServiceId and Version of this service
 	 * given the servicePath.
-	 * 
+	 *
 	 * @param servicePath - the path of the backend service
 	 * @return
 	 */
-	public String[] getApiManagerServiceInfo(String servicePath);
+	public ServiceMapping getApiManagerServiceMapping(String servicePath);
 }

--- a/components/gateway-api/src/main/java/io/fabric8/gateway/api/apimanager/ServiceMapping.java
+++ b/components/gateway-api/src/main/java/io/fabric8/gateway/api/apimanager/ServiceMapping.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.api.apimanager;
+
+/**
+ * A simple java bean modelling a service mapping.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class ServiceMapping {
+
+    private String path;
+    private String organizationId;
+    private String serviceId;
+    private String version;
+
+    /**
+     * Constructor.
+     */
+    public ServiceMapping() {
+    }
+
+    /**
+     * Constructor.
+     * @param path
+     * @param organizationId
+     * @param serviceId
+     * @param version
+     */
+    public ServiceMapping(String path, String organizationId, String serviceId, String version) {
+        setPath(path);
+        setOrganizationId(organizationId);
+        setServiceId(serviceId);
+        setVersion(version);
+    }
+
+    /**
+     * @return the path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * @param path the path to set
+     */
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    /**
+     * @return the organizationId
+     */
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    /**
+     * @param organizationId the organizationId to set
+     */
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    /**
+     * @return the serviceId
+     */
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    /**
+     * @param serviceId the serviceId to set
+     */
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
+    /**
+     * @return the version
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @param version the version to set
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+}

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ApiManEngine.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ApiManEngine.java
@@ -3,9 +3,10 @@ package io.fabric8.gateway.apiman;
 import io.apiman.gateway.api.rest.contract.exceptions.NotAuthorizedException;
 import io.apiman.gateway.engine.IEngine;
 import io.apiman.gateway.engine.beans.Service;
+import io.fabric8.gateway.api.apimanager.ServiceMapping;
 
 public interface ApiManEngine extends IEngine {
 
 	public String serviceMapping(Service service) throws NotAuthorizedException;
-	public String[] getServiceInfo(String serviceBindPath);
+	public ServiceMapping getServiceMapping(String serviceBindPath);
 }

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ApiManHttpGatewayHandler.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ApiManHttpGatewayHandler.java
@@ -30,6 +30,7 @@ import io.apiman.gateway.engine.io.ISignalWriteStream;
 import io.apiman.gateway.vertx.io.VertxApimanBuffer;
 import io.fabric8.gateway.api.CallDetailRecord;
 import io.fabric8.gateway.api.apimanager.ApiManagerService;
+import io.fabric8.gateway.api.apimanager.ServiceMapping;
 import io.fabric8.gateway.api.handlers.http.HttpGateway;
 import io.fabric8.gateway.api.handlers.http.HttpMapping;
 import io.fabric8.gateway.api.handlers.http.IMappedServices;
@@ -97,11 +98,11 @@ public class ApiManHttpGatewayHandler implements Handler<HttpServerRequest> {
 	        IMappedServices mappedServices = HttpMapping.getMapping(request, httpGateway.getMappedServices());
 	        if (mappedServices!=null) {
 		    	ProxyMappingDetails proxyMappingDetails = mappedServices.getProxyMappingDetails();
-		        String[] apiManagerServiceInfo = apiManager.getApiManagerServiceInfo(proxyMappingDetails.getServicePath());
+		        ServiceMapping apiManagerServiceInfo = apiManager.getApiManagerServiceMapping(proxyMappingDetails.getServicePath());
 		        if (apiManagerServiceInfo==null) throw new Exception("Service Not Found in API Manager.");
-		        srequest.setServiceOrgId(apiManagerServiceInfo[0]);
-		        srequest.setServiceId(apiManagerServiceInfo[1]);
-		        srequest.setServiceVersion(apiManagerServiceInfo[2]);
+		        srequest.setServiceOrgId(apiManagerServiceInfo.getOrganizationId());
+		        srequest.setServiceId(apiManagerServiceInfo.getServiceId());
+		        srequest.setServiceVersion(apiManagerServiceInfo.getVersion());
 	        } else {
 	        	throw new Exception("Service Not Found in API Manager.");
 	        }

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ESServiceMappingStorage.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ESServiceMappingStorage.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.apiman;
+
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.apiman.gateway.engine.es.ESClientFactory;
+import io.apiman.gateway.engine.es.ESConstants;
+import io.fabric8.gateway.api.apimanager.ServiceMapping;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.JestResultHandler;
+import io.searchbox.core.Delete;
+import io.searchbox.core.Get;
+import io.searchbox.core.Index;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * An elasticsearch implementation of a service mapping storage.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class ESServiceMappingStorage implements ServiceMappingStorage {
+
+    private Map<String, String> config;
+    private JestClient esClient;
+
+    /**
+     * Constructor.
+     * @param esConfig
+     */
+    public ESServiceMappingStorage(Map<String, String> esConfig) {
+        this.config = esConfig;
+    }
+
+    /**
+     * @return the esClient
+     */
+    public synchronized JestClient getClient() {
+        if (esClient == null) {
+            esClient = ESClientFactory.createClient(config);
+        }
+        return esClient;
+    }
+
+    /**
+     * @see io.fabric8.gateway.apiman.ServiceMappingStorage#put(java.lang.String, io.fabric8.gateway.api.apimanager.ServiceMapping, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @Override
+    public void put(final String path, final ServiceMapping mapping, final IAsyncResultHandler<Void> handler) {
+        String id = idFromPath(path);
+        Index index = new Index.Builder(mapping).refresh(false)
+                .index(ESConstants.INDEX_NAME)
+                .type("f8_service_mapping").id(id).build(); //$NON-NLS-1$
+        try {
+            getClient().executeAsync(index, new JestResultHandler<JestResult>() {
+                @Override
+                public void completed(JestResult result) {
+                    if (!result.isSucceeded()) {
+                        handler.handle(AsyncResultImpl.create(new Exception(
+                                "Failed to store service mapping for path: " + path), //$NON-NLS-1$
+                                Void.class));
+                    } else {
+                        handler.handle(AsyncResultImpl.create((Void) null));
+                    }
+                }
+                @Override
+                public void failed(Exception e) {
+                    handler.handle(AsyncResultImpl.create(new Exception(
+                            "Error storing service mapping for path: " + path, e), //$NON-NLS-1$
+                            Void.class));
+                }
+            });
+        } catch (ExecutionException | InterruptedException | IOException e) {
+            handler.handle(AsyncResultImpl.create(new Exception(
+                    "Error storing service mapping for path: " + path, e), //$NON-NLS-1$
+                    Void.class));
+        }
+
+    }
+
+    /**
+     * Creates an ES document id from the given path.
+     * @param path
+     */
+    private String idFromPath(String path) {
+        return Base64.encodeBase64String(path.getBytes());
+    }
+
+    /**
+     * @see io.fabric8.gateway.apiman.ServiceMappingStorage#get(java.lang.String)
+     */
+    @Override
+    public ServiceMapping get(String path) {
+        String id = idFromPath(path);
+        Get get = new Get.Builder(ESConstants.INDEX_NAME, id).type("f8_service_mapping").build(); //$NON-NLS-1$
+        try {
+            JestResult result = getClient().execute(get);
+            if (result.isSucceeded()) {
+                return result.getSourceAsObject(ServiceMapping.class);
+            }
+            return null;
+        } catch (Exception e) {
+            // TODO log this error
+            return null;
+        }
+    }
+
+    /**
+     * @see io.fabric8.gateway.apiman.ServiceMappingStorage#remove(java.lang.String, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @Override
+    public void remove(final String path, final IAsyncResultHandler<Void> handler) {
+        String id = idFromPath(path);
+        Delete delete = new Delete.Builder(id).index(ESConstants.INDEX_NAME).type("f8_service_mapping").build(); //$NON-NLS-1$
+        try {
+            getClient().executeAsync(delete, new JestResultHandler<JestResult>() {
+                @Override
+                public void completed(JestResult result) {
+                    if (result.isSucceeded()) {
+                        handler.handle(AsyncResultImpl.create((Void) null));
+                    } else {
+                        handler.handle(AsyncResultImpl.create(new Exception("Failed to remove mapping at path: " + path), Void.class)); //$NON-NLS-1$
+                    }
+                }
+                @Override
+                public void failed(Exception e) {
+                    handler.handle(AsyncResultImpl.create(new Exception("Error removing mapping at path: " + path, e), Void.class)); //$NON-NLS-1$
+                }
+            });
+        } catch (ExecutionException | InterruptedException | IOException e) {
+            handler.handle(AsyncResultImpl.create(new Exception("Error removing mapping at path: " + path, e), Void.class)); //$NON-NLS-1$
+        }
+    }
+
+}

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/Engine.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/Engine.java
@@ -24,6 +24,7 @@ import io.apiman.gateway.engine.IServiceRequestExecutor;
 import io.apiman.gateway.engine.async.IAsyncResultHandler;
 import io.apiman.gateway.engine.beans.Service;
 import io.apiman.gateway.engine.beans.ServiceRequest;
+import io.fabric8.gateway.api.apimanager.ServiceMapping;
 import io.fabric8.gateway.api.handlers.http.HttpGateway;
 import io.fabric8.gateway.api.handlers.http.IMappedServices;
 
@@ -88,7 +89,7 @@ public class Engine {
 			}
 
 			@Override
-			public String[] getServiceInfo(String servicePath) {
+			public ServiceMapping getServiceMapping(String servicePath) {
 				return ((DelegatingRegistryWithMapping) engine.getRegistry()).getService(servicePath);
 			}
 		};

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/EngineFactory.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/EngineFactory.java
@@ -59,10 +59,10 @@ public class EngineFactory extends DefaultEngineFactory {
         this.httpGateway = httpGateway;
 
         // TODO use proper/dynamic configuration values for these!
-        esConfig.put("client.type", "transport");
+        esConfig.put("client.type", "jest");
         esConfig.put("client.cluster-name", "apiman");
         esConfig.put("client.host", "localhost");
-        esConfig.put("client.port", "9300");
+        esConfig.put("client.port", "9200");
     }
 
     /**
@@ -84,7 +84,9 @@ public class EngineFactory extends DefaultEngineFactory {
 
     @Override
     protected IRegistry createRegistry() {
-        return new DelegatingRegistryWithMapping(new ESRegistry(esConfig));
+        ESRegistry registry = new ESRegistry(esConfig);
+        ServiceMappingStorage mappingStorage = new ESServiceMappingStorage(esConfig);
+        return new DelegatingRegistryWithMapping(registry, mappingStorage);
     }
 
     /**

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/InMemoryEngineFactory.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/InMemoryEngineFactory.java
@@ -61,7 +61,9 @@ public class InMemoryEngineFactory extends DefaultEngineFactory {
 
     @Override
     protected IRegistry createRegistry() {
-        return new DelegatingRegistryWithMapping(new InMemoryRegistry());
+        InMemoryRegistry registry = new InMemoryRegistry();
+        ServiceMappingStorage mappingStorage = new InMemoryServiceMappingStorage();
+        return new DelegatingRegistryWithMapping(registry, mappingStorage);
     }
 
     /**

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/InMemoryServiceMappingStorage.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/InMemoryServiceMappingStorage.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.apiman;
+
+import io.apiman.gateway.engine.async.AsyncResultImpl;
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.fabric8.gateway.api.apimanager.ServiceMapping;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An in-memory (Map<>) implementation of a service mapping storage.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public class InMemoryServiceMappingStorage implements ServiceMappingStorage {
+
+    private Map<String, ServiceMapping> mappings = new HashMap<String, ServiceMapping>();
+
+    /**
+     * Constructor.
+     */
+    public InMemoryServiceMappingStorage() {
+    }
+
+    /**
+     * @see io.fabric8.gateway.apiman.ServiceMappingStorage#put(java.lang.String, io.fabric8.gateway.api.apimanager.ServiceMapping, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @Override
+    public void put(String path, ServiceMapping mapping, IAsyncResultHandler<Void> handler) {
+        mappings.put(path, mapping);
+        handler.handle(AsyncResultImpl.create((Void) null));
+    }
+
+    /**
+     * @see io.fabric8.gateway.apiman.ServiceMappingStorage#get(java.lang.String)
+     */
+    @Override
+    public ServiceMapping get(String path) {
+        return mappings.get(path);
+    }
+
+    /**
+     * @see io.fabric8.gateway.apiman.ServiceMappingStorage#remove(java.lang.String, io.apiman.gateway.engine.async.IAsyncResultHandler)
+     */
+    @Override
+    public void remove(String path, IAsyncResultHandler<Void> handler) {
+        mappings.remove(path);
+        handler.handle(AsyncResultImpl.create((Void) null));
+    }
+
+}

--- a/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ServiceMappingStorage.java
+++ b/components/gateway-apiman/src/main/java/io/fabric8/gateway/apiman/ServiceMappingStorage.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.gateway.apiman;
+
+import io.apiman.gateway.engine.async.IAsyncResultHandler;
+import io.fabric8.gateway.api.apimanager.ServiceMapping;
+
+/**
+ * Used to store the service mapping information into some form of
+ * persistent storage.  This must be done asynchronously.
+ *
+ * @author eric.wittmann@redhat.com
+ */
+public interface ServiceMappingStorage {
+
+    /**
+     * @param path
+     * @param mapping
+     * @param iAsyncResultHandler
+     */
+    public void put(String path, ServiceMapping mapping, IAsyncResultHandler<Void> iAsyncResultHandler);
+
+    /**
+     * @param path
+     * @return
+     */
+    public ServiceMapping get(String path);
+
+    /**
+     * @param path
+     * @param iAsyncResultHandler
+     */
+    public void remove(String path, IAsyncResultHandler<Void> iAsyncResultHandler);
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <aether.version>1.11</aether.version>
         <ant.bundle.version>1.8.2_2</ant.bundle.version>
         <antlr.version>3.3</antlr.version>
-        <apiman.version>1.1.2.Preview2</apiman.version>
+        <apiman.version>1.1.3-SNAPSHOT</apiman.version>
         <archetype-packaging.version>2.2</archetype-packaging.version>
         <aries-blueprint-api.version>1.0.1</aries-blueprint-api.version>
         <aries-blueprint-cm.version>1.0.4</aries-blueprint-cm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <aether.version>1.11</aether.version>
         <ant.bundle.version>1.8.2_2</ant.bundle.version>
         <antlr.version>3.3</antlr.version>
-        <apiman.version>1.1.3-SNAPSHOT</apiman.version>
+        <apiman.version>1.1.3.CR1</apiman.version>
         <archetype-packaging.version>2.2</archetype-packaging.version>
         <aries-blueprint-api.version>1.0.1</aries-blueprint-api.version>
         <aries-blueprint-cm.version>1.0.4</aries-blueprint-cm.version>


### PR DESCRIPTION
This update replaces the TransportClient with the JestClient in the apiman runtime components (registry, shared state, rate limiting).  It also enables persistence (again via elasticsearch) for the API Gateway's service mappings.

@KurtStam - could you have a look at this PR before it gets merged?

Work still to be done:  
* connecting the ES components to the running fabric8 instance of elasticsearch
