### PR TITLE
Look up host/port of elasticsearch instead of hard-coding

### DIFF
--- a/components/gateway-apiman/pom.xml
+++ b/components/gateway-apiman/pom.xml
@@ -62,6 +62,10 @@
             <groupId>io.fabric8</groupId>
             <artifactId>gateway-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>fabric8-utils</artifactId>
+        </dependency>
 
 	    <!--  API Man -->
         <dependency>


### PR DESCRIPTION
Using the environment and fabric8 tools to lookup the location of the ES service.