### PR TITLE
Add route for 'docker-registry.vagrant.local'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,6 +58,25 @@ cat <<EOF | osc create -f -
     admin-cert: "$(base64 -w 0 /var/lib/openshift/openshift.local.config/master/admin.crt)"
     admin-key: "$(base64 -w 0 /var/lib/openshift/openshift.local.config/master/admin.key)"
 EOF
+
+# Create route to registry
+cat <<EOF | osc create -f -
+{
+    "kind": "Route",
+    "apiVersion": "v1beta3",
+    "metadata": {
+        "name": "docker-registry-route"
+    },
+    "spec": {
+        "host": "docker-registry.vagrant.local",
+        "to": {
+            "kind": "Service",
+            "name": "docker-registry"
+        }
+    }
+}
+EOF
+
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
This is done during provisioning the Vagrant VM so that everybody
can reference to the OS registry with `docker-registry.vagrant.local`
For this to work, /etc/hosts should contain at least an entry

172.28.128.4 vagrant.local docker-registry.vagrant.local

so that this host points to the proper IP.