### PR TITLE
fix for the docs for the right fabric8 maven plugin version

### DIFF
--- a/docs/fabric8OnOpenShift.md
+++ b/docs/fabric8OnOpenShift.md
@@ -128,11 +128,11 @@ Before you start make sure you have [setup your local machine](setupLocalHost.ht
 
 If you have defined the [$KUBERNETES_DOMAIN environment variable](#setup-domain) then you can use the following command:
 
-    mvn io.fabric8:fabric8-maven-plugin:2.1.1:create-routes
+    mvn io.fabric8:fabric8-maven-plugin:2.1.3:create-routes
 
 Otherwise you can be specific and specify the domain you wish to use:
 
-    mvn io.fabric8:fabric8-maven-plugin:2.1.1:create-routes -Dfabric8.domain=my.acme.com
+    mvn io.fabric8:fabric8-maven-plugin:2.1.3:create-routes -Dfabric8.domain=my.acme.com
 
 You could then setup a wildcard DNS rule on `*.$KUBERNETES_DOMAIN` to point to the IP address of your OpenShift master or haproxy installation. Or you could add custom entries to your `/etc/hosts` file for each service.
                                                                                                          


### PR DESCRIPTION
The current version of the docs uses a fabric8 maven plugin version (2.1.1) that breaks when setting up the routes, this fix basically updates the docs to use 2.1.3 which seems to work well.