### PR TITLE
fixes #4037 so that iconUrl annotations are easily composable in templates. the downside that means we can't really combine multiple data urls into a template any more; so for now only use data urls if the icon is about 2k (which would allow about 20-ish apps per template if each has a data url). Also avoid the "-service" / "-controller" / "-route" suffixes for generated controllers / routes for #4039

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/extensions/Templates.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/extensions/Templates.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 
 import static io.fabric8.kubernetes.api.KubernetesFactory.createObjectMapper;
@@ -80,6 +81,20 @@ public class Templates {
             firstTemplate.setParameters(parameters);
         }
         combineParameters(parameters, template.getParameters());
+        String name = KubernetesHelper.getName(template);
+        if (Strings.isNotBlank(name)) {
+            // lets merge all the fabric8 annotations using the template id qualifier as a postfix
+            Map<String, String> annotations = KubernetesHelper.getOrCreateAnnotations(firstTemplate);
+            Map<String, String> otherAnnotations = KubernetesHelper.getOrCreateAnnotations(template);
+            Set<Map.Entry<String, String>> entries = otherAnnotations.entrySet();
+            for (Map.Entry<String, String> entry : entries) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                if (!annotations.containsKey(key)) {
+                    annotations.put(key, value);
+                }
+            }
+        }
         return firstTemplate;
     }
 

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/AnnotationKeys.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/AnnotationKeys.java
@@ -21,8 +21,10 @@ package io.fabric8.maven;
  */
 public class AnnotationKeys {
 
-    public static final String ICON_URL = "fabric8/iconUrl";
-    public static final String SUMMARY = "fabric8/summary";
-    public static final String DESCRIPTION = "fabric8/description";
+    public static final String PREFIX = "fabric8.";
+
+    public static final String ICON_URL = "iconUrl";
+    public static final String SUMMARY = "summary";
+    public static final String DESCRIPTION = "description";
 
 }

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/ApplyMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/ApplyMojo.java
@@ -219,7 +219,8 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         String id = KubernetesHelper.getName(service);
         if (Strings.isNotBlank(id) && shouldCreateRouteForService(log, service, id)) {
             route = new Route();
-            KubernetesHelper.setName(route, namespace, id + "-route");
+            String routeId = id;
+            KubernetesHelper.setName(route, namespace, routeId);
             RouteSpec routeSpec = new RouteSpec();
             ObjectReference objectRef = new ObjectReference();
             objectRef.setName(id);

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
@@ -247,7 +247,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
     /**
      * The replication controller name used in the generated Kubernetes JSON template
      */
-    @Parameter(property = "fabric8.replicationController.name", defaultValue = "${project.artifactId}-controller")
+    @Parameter(property = "fabric8.replicationController.name", defaultValue = "${project.artifactId}")
     private String replicationControllerName;
 
     /**
@@ -259,7 +259,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
     /**
      * The name label used in the generated Kubernetes JSON template
      */
-    @Parameter(property = "fabric8.container.name", defaultValue = "${project.artifactId}-container")
+    @Parameter(property = "fabric8.container.name", defaultValue = "${project.artifactId}")
     private String kubernetesContainerName;
 
     /**
@@ -331,7 +331,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
      * Defines the maximum size in kilobytes that the data encoded URL of the icon should be before we defer
      * and try to use an external URL
      */
-    @Parameter(property = "fabric8.maximumDataUrlSizeK", defaultValue = "36")
+    @Parameter(property = "fabric8.maximumDataUrlSizeK", defaultValue = "2")
     private int maximumDataUrlSizeK;
 
     @Component
@@ -684,7 +684,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
             Map<String, String> annotations = KubernetesHelper.getOrCreateAnnotations(template);
             addDocumentationAnnotations(template, annotations);
             if (hasUrl) {
-                annotations.put(AnnotationKeys.ICON_URL, iconUrl);
+                annotations.put(getTemplateKey(template, AnnotationKeys.ICON_URL), iconUrl);
             }
 
             builder = builder.addToTemplateItems(template);
@@ -704,6 +704,14 @@ public class JsonMojo extends AbstractFabric8Mojo {
         }
     }
 
+    protected String getTemplateKey(Template template, String key) {
+        String name = getName(template);
+        if (Strings.isNullOrBlank(name)) {
+            name = getProject().getArtifactId();
+        }
+        return AnnotationKeys.PREFIX + name + "/" + key;
+    }
+
     protected void addDocumentationAnnotations(Template template, Map<String, String> annotations) {
         // we want summary before description
         try {
@@ -717,7 +725,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
         if (summary.exists() && summary.isFile()) {
             try {
                 String text = Files.toString(summary);
-                annotations.put(AnnotationKeys.SUMMARY, text);
+                annotations.put(getTemplateKey(template, AnnotationKeys.SUMMARY), text);
             } catch (IOException e) {
                 getLog().warn("Failed to load " + summary + ". " + e, e);
             }
@@ -809,7 +817,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
                                 String[] prefixes = {"http://github.com/", "https://github.com/"};
                                 for (String prefix : prefixes) {
                                     if (url.startsWith(prefix)) {
-                                        url = URLUtils.pathJoin("https://raw.githubusercontent.com/", url.substring(prefix.length()));
+                                        url = URLUtils.pathJoin("https://cdn.rawgit.com/", url.substring(prefix.length()));
                                         break;
                                     }
                                 }


### PR DESCRIPTION
fixes #4037 so that iconUrl annotations are easily composable in templates. the downside that means we can't really combine multiple data urls into a template any more; so for now only use data urls if the icon is about 2k (which would allow about 20-ish apps per template if each has a data url). Also avoid the "-service" / "-controller" / "-route" suffixes for generated controllers / routes for #4039