### PR TITLE
add a resteasy version of gitrepo-api which uses resteasy which doesn't use cxf and so doesnt' use spring so might stand a chance running inside jenkins with spring 2.5.x wired on the global classpath

### DIFF
--- a/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GitRepoClient.java
+++ b/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GitRepoClient.java
@@ -17,15 +17,10 @@
  */
 package io.fabric8.repo.git;
 
-import io.fabric8.utils.Strings;
-import io.fabric8.utils.cxf.TrustEverythingSSLTrustManager;
 import io.fabric8.utils.cxf.WebClients;
-import org.apache.cxf.configuration.jsse.TLSClientParameters;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
 import org.apache.cxf.jaxrs.client.WebClient;
-import org.apache.cxf.transport.http.HTTPConduit;
 
-import javax.net.ssl.TrustManager;
 import java.util.List;
 
 import static io.fabric8.utils.cxf.WebClients.configureUserAndPassword;
@@ -35,49 +30,17 @@ import static io.fabric8.utils.cxf.WebClients.disableSslChecks;
  * A client API for working with git hosted repositories using back ends like
  * <a href="http://gogs.io/">gogs</a> or <a href="http://github.com/">github</a>
  */
-public class GitRepoClient {
-    private final String address;
-    private final String username;
-    private final String password;
-    private GitApi api;
+public class GitRepoClient extends GitRepoClientSupport {
 
     public GitRepoClient(String address, String username, String password) {
-        this.address = address;
-        this.username = username;
-        this.password = password;
+        super(address, username, password);
     }
 
-    public RepositoryDTO createRepository(CreateRepositoryDTO createRepository) {
-        return getApi().createRepository(createRepository);
-    }
-
-    public List<RepositoryDTO> listRepositories() {
-        return getApi().listRepositories();
-    }
-
-    public List<RepositoryDTO> listOrganisationRepositories(String organisation) {
-        return getApi().listOrganisationRepositories(organisation);
-    }
-
-    public List<OrganisationDTO> listUserOrganisations() {
-        return getApi().listUserOrganisations();
-    }
-
-
-    public WebHookDTO createWebhook(String owner, String repo, CreateWebhookDTO dto) {
-        return getApi().createWebhook(owner, repo, dto);
-    }
-
-    protected GitApi getApi() {
-        if (api == null) {
-            api = createWebClient(GitApi.class);
-        }
-        return api;
-    }
 
     /**
      * Creates a JAXRS web client for the given JAXRS client
      */
+    @Override
     protected <T> T createWebClient(Class<T> clientType) {
         List<Object> providers = WebClients.createProviders();
         WebClient webClient = WebClient.create(address, providers);
@@ -85,7 +48,5 @@ public class GitRepoClient {
         configureUserAndPassword(webClient, username, password);
         return JAXRSClientFactory.fromClient(webClient, clientType);
     }
-
-
 
 }

--- a/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GitRepoClientSupport.java
+++ b/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GitRepoClientSupport.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.repo.git;
+
+import java.util.List;
+
+/**
+ */
+public abstract class GitRepoClientSupport {
+    protected final String address;
+    protected final String username;
+    protected final String password;
+    private GitApi api;
+
+    public GitRepoClientSupport(String address, String username, String password) {
+        this.address = address;
+        this.password = password;
+        this.username = username;
+    }
+
+    public List<RepositoryDTO> listRepositories() {
+        return getApi().listRepositories();
+    }
+
+    public List<RepositoryDTO> listOrganisationRepositories(String organisation) {
+        return getApi().listOrganisationRepositories(organisation);
+    }
+
+    public List<OrganisationDTO> listUserOrganisations() {
+        return getApi().listUserOrganisations();
+    }
+
+    public WebHookDTO createWebhook(String owner, String repo, CreateWebhookDTO dto) {
+        return getApi().createWebhook(owner, repo, dto);
+    }
+
+    public RepositoryDTO createRepository(CreateRepositoryDTO createRepository) {
+        return getApi().createRepository(createRepository);
+    }
+
+
+    protected GitApi getApi() {
+        if (api == null) {
+            api = createWebClient(GitApi.class);
+        }
+        return api;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    protected abstract <T> T createWebClient(Class<T> clientType);
+}

--- a/components/gitrepo-resteasy/pom.xml
+++ b/components/gitrepo-resteasy/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2014 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.fabric8</groupId>
+    <artifactId>components</artifactId>
+    <version>2.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>gitrepo-resteasy</artifactId>
+  <name>Fabric8 :: Git Repo :: RestEasy</name>
+
+  <properties>
+    <resteasy.version>3.0.9.Final</resteasy.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>gitrepo-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-rt-rs-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.fabric8</groupId>
+          <artifactId>cxf-utils</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>jaxrs-api</artifactId>
+      <version>${resteasy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${resteasy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jackson2-provider</artifactId>
+      <version>${resteasy.version}</version>
+    </dependency>
+
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${exec-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>io.fabric8.repo.git.resteasy.Example</mainClass>
+          <classpathScope>test</classpathScope>
+          <arguments>
+            <argument>${gogsAddress}</argument>
+            <argument>jenkins</argument>
+            <argument>adminadmin</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/components/gitrepo-resteasy/src/main/java/io/fabric8/repo/git/resteasy/ResteasyGitRepoClient.java
+++ b/components/gitrepo-resteasy/src/main/java/io/fabric8/repo/git/resteasy/ResteasyGitRepoClient.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.repo.git.resteasy;
+
+import io.fabric8.repo.git.GitRepoClientSupport;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient4Engine;
+import org.jboss.resteasy.plugins.providers.DefaultTextPlain;
+import org.jboss.resteasy.plugins.providers.FileProvider;
+import org.jboss.resteasy.plugins.providers.InputStreamProvider;
+import org.jboss.resteasy.plugins.providers.StringTextStar;
+import org.jboss.resteasy.plugins.providers.jackson.Jackson2JsonpInterceptor;
+import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+/**
+ * A client API for working with git hosted repositories using back ends like
+ * <a href="http://gogs.io/">gogs</a> or <a href="http://github.com/">github</a>
+ */
+public class ResteasyGitRepoClient extends GitRepoClientSupport {
+
+    public ResteasyGitRepoClient(String address, String username, String password) {
+        super(address, username, password);
+    }
+
+    /**
+     * Creates a JAXRS web client for the given JAXRS client
+     */
+    protected <T> T createWebClient(Class<T> clientType) {
+        String address = getAddress();
+
+        ResteasyProviderFactory providerFactory = ResteasyProviderFactory.getInstance();
+        providerFactory.register(ResteasyJackson2Provider.class);
+        providerFactory.register(Jackson2JsonpInterceptor.class);
+        providerFactory.register(StringTextStar.class);
+        providerFactory.register(DefaultTextPlain.class);
+        providerFactory.register(FileProvider.class);
+        providerFactory.register(InputStreamProvider.class);
+        providerFactory.register(new Authenticator());
+
+        ResteasyClientBuilder builder = new ResteasyClientBuilder();
+        builder.providerFactory(providerFactory);
+        builder.connectionPoolSize(3);
+
+        Client client = builder.build();
+        ResteasyWebTarget target = (ResteasyWebTarget) client.target(address);
+        return target.proxy(clientType);
+    }
+
+
+    protected class Authenticator implements ClientRequestFilter {
+
+        public void filter(ClientRequestContext requestContext) throws IOException {
+            MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+            final String basicAuthentication = getBasicAuthentication();
+            headers.add("Authorization", basicAuthentication);
+        }
+
+        private String getBasicAuthentication() {
+            String token = getUsername() + ":" + getPassword();
+            try {
+                return "Basic " +
+                     DatatypeConverter.printBase64Binary(token.getBytes("UTF-8"));
+            } catch (UnsupportedEncodingException ex) {
+                throw new IllegalStateException("Cannot encode with UTF-8", ex);
+            }
+        }
+    }
+}

--- a/components/gitrepo-resteasy/src/test/java/io/fabric8/repo/git/resteasy/Example.java
+++ b/components/gitrepo-resteasy/src/test/java/io/fabric8/repo/git/resteasy/Example.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.repo.git.resteasy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.fabric8.repo.git.RepositoryDTO;
+
+import java.util.List;
+
+public class Example {
+    public static void main(String[] args) {
+        if (args.length < 3) {
+            System.out.println("Usage: address userName password");
+            return;
+        }
+        String address = args[0];
+        String userName = args[1];
+        String password = args[2];
+
+        try {
+            ResteasyGitRepoClient client = new ResteasyGitRepoClient(address, userName, password);
+
+            List<RepositoryDTO> repositoryDTOs = client.listRepositories();
+
+            System.out.println("Got repositories: " + toJson(repositoryDTOs));
+        } catch (Exception e) {
+            System.out.println("Caught: " + e);
+            e.printStackTrace();
+        }
+    }
+
+    public static String toJson(Object dto) throws JsonProcessingException {
+        ObjectMapper mapper = createObjectMapper();
+        return mapper.writeValueAsString(dto);
+    }
+
+    /**
+     * Creates a configured Jackson object mapper for parsing JSON
+     */
+    public static ObjectMapper createObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        return mapper;
+    }
+}

--- a/components/gitrepo-resteasy/src/test/resources/log4j.properties
+++ b/components/gitrepo-resteasy/src/test/resources/log4j.properties
@@ -1,0 +1,34 @@
+#
+#  Copyright 2005-2014 Red Hat, Inc.
+#
+#  Red Hat licenses this file to you under the Apache License, version
+#  2.0 (the "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.  See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+#
+# The logging properties used during tests..
+#
+log4j.rootLogger=INFO, file
+
+#log4j.logger.io.fabric=DEBUG
+
+# CONSOLE appender not used by default
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+#log4j.appender.out.layout.ConversionPattern=[%30.30t] %-30.30c{1} %-5p %m%n
+log4j.appender.out.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+
+# File appender
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d [%-15.15t] %-5p %-30.30c{1} - %m%n
+log4j.appender.file.file=target/fabric-test.log

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -63,6 +63,7 @@
     <module>gateway-servlet</module>
     <module>gateway-servlet-example</module>
     <module>gitrepo-api</module>
+    <module>gitrepo-resteasy</module>
     <module>hubot-api</module>
     <module>jolokia-assertions</module>
     <module>karaf-features</module>


### PR DESCRIPTION
add a resteasy version of gitrepo-api which uses resteasy which doesn't use cxf and so doesnt' use spring so might stand a chance running inside jenkins with spring 2.5.x wired on the global classpath