### PR TITLE
default to IfNotPresent for snapshots to avoid requiring locally built images on a local vagrant box to need to be pushed and pulled

### DIFF
--- a/docs/mavenFabric8Json.md
+++ b/docs/mavenFabric8Json.md
@@ -127,7 +127,7 @@ You can use maven properties to customize the generation of the JSON:
 </tr>
 <tr>
 <td>fabric8.imagePullPolicySnapshot</td>
-<td>Specifies the image pull policy used by default for <code>SNAPSHOT</code> maven versions. Defaults to <code>IfNotPresent</code> so that developers can build images locally in a vagrant image and not have to push or pull</td>
+<td>Specifies the image pull policy used by default for <code>SNAPSHOT</code> maven versions.</td>
 </tr>
 <tr>
 <td>fabric8.includeAllEnvironmentVariables</td>

--- a/docs/mavenFabric8Json.md
+++ b/docs/mavenFabric8Json.md
@@ -127,7 +127,7 @@ You can use maven properties to customize the generation of the JSON:
 </tr>
 <tr>
 <td>fabric8.imagePullPolicySnapshot</td>
-<td>Specifies the image pull policy used by default for <code>SNAPSHOT</code> maven versions. Defaults to <code>Always</code></td>
+<td>Specifies the image pull policy used by default for <code>SNAPSHOT</code> maven versions. Defaults to <code>IfNotPresent</code> so that developers can build images locally in a vagrant image and not have to push or pull</td>
 </tr>
 <tr>
 <td>fabric8.includeAllEnvironmentVariables</td>

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
@@ -298,7 +298,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
     /**
      * The docker image pull policy for snapshot releases (which should pull always)
      */
-    @Parameter(property = "fabric8.imagePullPolicySnapshot", defaultValue = "Always")
+    @Parameter(property = "fabric8.imagePullPolicySnapshot", defaultValue = "IfNotPresent")
     private String imagePullPolicySnapshot;
 
     /**

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/JsonMojo.java
@@ -298,7 +298,7 @@ public class JsonMojo extends AbstractFabric8Mojo {
     /**
      * The docker image pull policy for snapshot releases (which should pull always)
      */
-    @Parameter(property = "fabric8.imagePullPolicySnapshot", defaultValue = "IfNotPresent")
+    @Parameter(property = "fabric8.imagePullPolicySnapshot")
     private String imagePullPolicySnapshot;
 
     /**


### PR DESCRIPTION
default to IfNotPresent for snapshots to avoid requiring locally built images on a local vagrant box to need to be pushed and pulled