### PR TITLE
handle 404 nicely when looking up a build config that doesn't exist

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesClient.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesClient.java
@@ -853,9 +853,14 @@ public class KubernetesClient implements Kubernetes, KubernetesExtensions, Kuber
     @Override
     @GET
     @Path("buildConfigs/{name}")
-    public BuildConfig getBuildConfig(@NotNull String name, String namespace) {
+    public BuildConfig getBuildConfig(final @NotNull String name, final String namespace) {
         validateNamespace(namespace, name);
-        return getKubernetesExtensions().getBuildConfig(name, namespace);
+        return handle404ByReturningNull(new Callable<BuildConfig>() {
+            @Override
+            public BuildConfig call() throws Exception {
+                return getKubernetesExtensions().getBuildConfig(name, namespace);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
handle 404 nicely when looking up a build config that doesn't exist