### PR TITLE
Camel forge commands for xml should not require java source facet as …

### DIFF
--- a/forge/addons/camel/src/main/java/io/fabric8/forge/camel/commands/project/CamelAddEndpointXmlCommand.java
+++ b/forge/addons/camel/src/main/java/io/fabric8/forge/camel/commands/project/CamelAddEndpointXmlCommand.java
@@ -23,7 +23,6 @@ import io.fabric8.forge.camel.commands.project.completer.XmlFileCompleter;
 import io.fabric8.forge.camel.commands.project.helper.CamelCommandsHelper;
 import org.jboss.forge.addon.dependencies.DependencyResolver;
 import org.jboss.forge.addon.facets.constraints.FacetConstraint;
-import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
 import org.jboss.forge.addon.projects.Project;
 import org.jboss.forge.addon.projects.dependencies.DependencyInstaller;
 import org.jboss.forge.addon.projects.facets.ClassLoaderFacet;
@@ -43,7 +42,7 @@ import org.jboss.forge.addon.ui.util.Categories;
 import org.jboss.forge.addon.ui.util.Metadata;
 import org.jboss.forge.addon.ui.wizard.UIWizard;
 
-@FacetConstraint({JavaSourceFacet.class, ResourcesFacet.class, ClassLoaderFacet.class})
+@FacetConstraint({ResourcesFacet.class, ClassLoaderFacet.class})
 public class CamelAddEndpointXmlCommand extends AbstractCamelProjectCommand implements UIWizard {
 
     @Inject

--- a/forge/addons/camel/src/main/java/io/fabric8/forge/camel/commands/project/CamelEditEndpointXmlCommand.java
+++ b/forge/addons/camel/src/main/java/io/fabric8/forge/camel/commands/project/CamelEditEndpointXmlCommand.java
@@ -22,7 +22,6 @@ import io.fabric8.forge.camel.commands.project.completer.XmlEndpointsCompleter;
 import io.fabric8.forge.camel.commands.project.helper.CamelCommandsHelper;
 import org.jboss.forge.addon.dependencies.DependencyResolver;
 import org.jboss.forge.addon.facets.constraints.FacetConstraint;
-import org.jboss.forge.addon.parser.java.facets.JavaSourceFacet;
 import org.jboss.forge.addon.projects.Project;
 import org.jboss.forge.addon.projects.dependencies.DependencyInstaller;
 import org.jboss.forge.addon.projects.facets.ClassLoaderFacet;
@@ -41,7 +40,7 @@ import org.jboss.forge.addon.ui.util.Categories;
 import org.jboss.forge.addon.ui.util.Metadata;
 import org.jboss.forge.addon.ui.wizard.UIWizard;
 
-@FacetConstraint({JavaSourceFacet.class, ResourcesFacet.class, ClassLoaderFacet.class})
+@FacetConstraint({ResourcesFacet.class, ClassLoaderFacet.class})
 public class CamelEditEndpointXmlCommand extends AbstractCamelProjectCommand implements UIWizard {
 
     @Inject


### PR DESCRIPTION
…the project may not have java code and therefore the facet is not there, and the commands would be disabled.