### PR TITLE
#4063 default jenkins webhook by default in the existing fabric8:create-build-config goal; as it knows the jenkins details and allow it to also do taiga if its given a taiga project name for #4149

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateGogsWebhook.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateGogsWebhook.java
@@ -16,19 +16,15 @@
  */
 package io.fabric8.maven;
 
-import io.fabric8.kubernetes.api.Controller;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.fabric8.kubernetes.api.KubernetesClient;
 import io.fabric8.kubernetes.api.ServiceNames;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceList;
-import io.fabric8.openshift.api.model.Route;
 import io.fabric8.repo.git.CreateWebhookDTO;
 import io.fabric8.repo.git.GitRepoClient;
 import io.fabric8.repo.git.WebHookDTO;
 import io.fabric8.repo.git.WebhookConfig;
 import io.fabric8.utils.Objects;
 import io.fabric8.utils.Strings;
-import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -37,7 +33,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.util.List;
 
-import static io.fabric8.kubernetes.api.KubernetesHelper.getName;
 import static io.fabric8.utils.cxf.JsonHelper.toJson;
 
 /**
@@ -78,54 +73,69 @@ public class CreateGogsWebhook extends AbstractNamespacedMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        // lets add defaults if not env vars
-        if (Strings.isNullOrBlank(gogsUsername)) {
-            gogsUsername = "gogsadmin";
-        }
-        if (Strings.isNullOrBlank(gogsPassword)) {
-            gogsPassword = "RedHat$1";
-        }
-
         try {
             KubernetesClient kubernetes = getKubernetes();
-            String namespace = kubernetes.getNamespace();
             Log log = getLog();
-            String gogsAddress = kubernetes.getServiceURL(ServiceNames.GOGS, namespace, "http", true);
-            log.info("Found gogs address: " + gogsAddress + " for namespace: " + namespace + " on Kubernetes address: " + kubernetes.getAddress());
-            if (Strings.isNullOrBlank(gogsAddress)) {
-                throw new MojoExecutionException("No address for service " + ServiceNames.GOGS + " in namespace: "
-                        + namespace  + " on Kubernetes address: " + kubernetes.getAddress());
-            }
-            log.info("Querying webhooks in gogs for namespace: " + namespace + " on Kubernetes address: " + kubernetes.getAddress());
+            String gogsUser = this.gogsUsername;
+            String gogsPwd = this.gogsPassword;
+            String repoName = this.repo;
+            String webhookUrlValue = this.webhookUrl;
+            String webhookSecret = this.secret;
 
-            GitRepoClient repoClient = new GitRepoClient(gogsAddress, gogsUsername, gogsPassword);
-            List<WebHookDTO> webhooks = repoClient.getWebhooks(gogsUsername, repo);
-            for (WebHookDTO webhook : webhooks) {
-                String url = null;
-                WebhookConfig config = webhook.getConfig();
-                if (config != null) {
-                    url = config.getUrl();
-                    if (Objects.equal(webhookUrl, url)) {
-                        log.info("Already has webhook for: " + url + " so not creating again");
-                        return;
-                    }
-                    log.info("Ignoring webhook " + url + " from: " + toJson(config));
-                }
-            }
-            CreateWebhookDTO createWebhook = new CreateWebhookDTO();
-            createWebhook.setType("gogs");
-            WebhookConfig config = createWebhook.getConfig();
-            config.setUrl(webhookUrl);
-            config.setSecret(secret);
-            WebHookDTO webhook = repoClient.createWebhook(gogsUsername, repo, createWebhook);
-            if (log.isDebugEnabled()) {
-                log.debug("Got created web hook: " + toJson(webhook));
-            }
-            log.info("Created webhook for " + webhookUrl + " for namespace: " + namespace + " on gogs URL: " + gogsAddress);
+            createGogsWebhook(kubernetes, log, gogsUser, gogsPwd, repoName, webhookUrlValue, webhookSecret);
         } catch (MojoExecutionException e) {
             throw e;
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to load environment schemas: " + e, e);
         }
+    }
+
+    /**
+     * Creates a webook in the given gogs repo for the user and password if the webhook does not already exist
+     */
+    public static boolean createGogsWebhook(KubernetesClient kubernetes, Log log, String gogsUser, String gogsPwd, String repoName, String webhookUrl, String webhookSecret) throws MojoExecutionException, JsonProcessingException {
+        // lets add defaults if not env vars
+        if (Strings.isNullOrBlank(gogsUser)) {
+            gogsUser = "gogsadmin";
+        }
+        if (Strings.isNullOrBlank(gogsPwd)) {
+            gogsPwd = "RedHat$1";
+        }
+
+
+        String namespace = kubernetes.getNamespace();
+        String gogsAddress = kubernetes.getServiceURL(ServiceNames.GOGS, namespace, "http", true);
+        log.info("Found gogs address: " + gogsAddress + " for namespace: " + namespace + " on Kubernetes address: " + kubernetes.getAddress());
+        if (Strings.isNullOrBlank(gogsAddress)) {
+            throw new MojoExecutionException("No address for service " + ServiceNames.GOGS + " in namespace: "
+                    + namespace  + " on Kubernetes address: " + kubernetes.getAddress());
+        }
+        log.info("Querying webhooks in gogs for namespace: " + namespace + " on Kubernetes address: " + kubernetes.getAddress());
+
+        GitRepoClient repoClient = new GitRepoClient(gogsAddress, gogsUser, gogsPwd);
+        List<WebHookDTO> webhooks = repoClient.getWebhooks(gogsUser, repoName);
+        for (WebHookDTO webhook : webhooks) {
+            String url = null;
+            WebhookConfig config = webhook.getConfig();
+            if (config != null) {
+                url = config.getUrl();
+                if (Objects.equal(webhookUrl, url)) {
+                    log.info("Already has webhook for: " + url + " so not creating again");
+                    return false;
+                }
+                log.info("Ignoring webhook " + url + " from: " + toJson(config));
+            }
+        }
+        CreateWebhookDTO createWebhook = new CreateWebhookDTO();
+        createWebhook.setType("gogs");
+        WebhookConfig config = createWebhook.getConfig();
+        config.setUrl(webhookUrl);
+        config.setSecret(webhookSecret);
+        WebHookDTO webhook = repoClient.createWebhook(gogsUser, repoName, createWebhook);
+        if (log.isDebugEnabled()) {
+            log.debug("Got created web hook: " + toJson(webhook));
+        }
+        log.info("Created webhook for " + webhookUrl + " for namespace: " + namespace + " on gogs URL: " + gogsAddress);
+        return true;
     }
 }


### PR DESCRIPTION
#4063 default jenkins webhook by default in the existing fabric8:create-build-config goal; as it knows the jenkins details and allow it to also do taiga if its given a taiga project name for #4149