### PR TITLE
Add instantiateBuild to Client

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesClient.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesClient.java
@@ -1004,6 +1004,14 @@ public class KubernetesClient implements Kubernetes, KubernetesExtensions, Kuber
         return getKubernetesExtensions().triggerBuild(name, namespace, secret, type, body);
     }
 
+    @Override
+    @POST
+    @Path("buildconfigs/{name}/instantiate")
+    public String instantiateBuild(@NotNull String name, BuildRequest request, String namespace) {
+        return getKubernetesExtensions().instantiateBuild(name, request, namespace);
+    }
+
+
     // Helper methods
     //-------------------------------------------------------------------------
     public void deletePod(Pod entity, String namespace) throws Exception {

--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesExtensions.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesExtensions.java
@@ -19,6 +19,7 @@ import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigList;
 import io.fabric8.openshift.api.model.BuildList;
+import io.fabric8.openshift.api.model.BuildRequest;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigList;
 import io.fabric8.openshift.api.model.ImageStream;
@@ -171,6 +172,11 @@ public interface KubernetesExtensions {
                         @PathParam("secret") @NotNull String secret,
                         @PathParam("type") @NotNull String type,
                         byte[] body);
+
+    @POST
+    @Path("buildconfigs/{name}/instantiate")
+    @Produces("application/json")
+    String instantiateBuild(@PathParam("name") String name, BuildRequest request, @PathParam("namespace") String namespace);
 
 
     // ImageRepositorys


### PR DESCRIPTION
Using the URL ..buildconfigs/{name}/instantiate instead of webhooks
have a few advantages:

* No BuildTriggers required on the BuildConfig
* No need to attempt to 'findLastBuild' since Build is the Response

**Depends on https://github.com/fabric8io/origin-schema-generator/pull/52** (and new release 0.0.47?)