### PR TITLE
Fix issue #4202. Move DTO to gitrepo-api. Change gerrit-address

### DIFF
--- a/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GerritGitApi.java
+++ b/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GerritGitApi.java
@@ -1,0 +1,13 @@
+package io.fabric8.repo.git;
+
+import javax.ws.rs.*;
+
+@Path("a")
+@Produces("application/json")
+@Consumes("application/json")
+public interface GerritGitApi {
+
+    @POST
+    @Path("projects/{repo}")
+    public GerritRepositoryDTO createRepository(@PathParam("repo") String repo, CreateRepositoryDTO dto);
+}

--- a/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GerritRepositoryDTO.java
+++ b/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GerritRepositoryDTO.java
@@ -1,0 +1,50 @@
+package io.fabric8.repo.git;
+
+public class GerritRepositoryDTO extends DtoSupport {
+
+    private String name;
+    private String description;
+    private String id;
+    private String parent;
+    private String state;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getParent() {
+        return parent;
+    }
+
+    public void setParent(String parent) {
+        this.parent = parent;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}


### PR DESCRIPTION
- Implements a ReaderInterceptor to remove the prefixed text of the HTTP message (Fix issue #4202)
- Move 2 internal classes under gitrepo-api maven module
- Change gerrit schema address to use the new one