### PR TITLE
Fixes #4194 Cleanup root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,18 +83,13 @@
         <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
 
         <activemq.version>5.11.1</activemq.version>
-        <aether.version>1.11</aether.version>
-        <ant.bundle.version>1.8.2_2</ant.bundle.version>
-        <antlr.version>3.3</antlr.version>
         <apiman.version>1.1.3.CR1</apiman.version>
         <archetype-packaging.version>2.2</archetype-packaging.version>
         <arquillian-core.version>1.1.7.Final</arquillian-core.version>
         <arquillian-junit-container.version>1.1.7.Final</arquillian-junit-container.version>
-        <arquillian-weld-ee-embedded.version>1.0.0.CR3</arquillian-weld-ee-embedded.version>
         <asm.version>5.0.3</asm.version>
         <assertj.core.version>1.7.0</assertj.core.version>
         <buildnumber.plugin.version>1.3</buildnumber.plugin.version>
-        <camel.version-range>[2.15,3)</camel.version-range>
         <camel.version>2.15.2</camel.version>
         <commons-codec.version>1.6</commons-codec.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
@@ -105,13 +100,10 @@
         <compiler.plugin.version>3.2</compiler.plugin.version>
         <curator.version>2.7.1</curator.version>
         <cxf.version>3.0.4</cxf.version>
-        <cxf.version-range>[3.0,4)</cxf.version-range>
         <deltaspike.version>1.0.3</deltaspike.version>
         <dnsjava.version>2.1.7</dnsjava.version>
-        <docker.maven.plugin.version>0.12.0</docker.maven.plugin.version>
         <dropwizard-metrics.version>3.1.0</dropwizard-metrics.version>
         <elasticsearch.version>1.3.2</elasticsearch.version>
-        <elasticsearch-zookeeper.version>1.3.2_1</elasticsearch-zookeeper.version>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <fabric8.release.version>2.0.48</fabric8.release.version>
         <felix-scr-annotations.version>1.9.8</felix-scr-annotations.version>
@@ -121,40 +113,26 @@
         <geronimo-jms.version>1.1.1</geronimo-jms.version>
         <geronimo-ws-metadata.version>1.1.3</geronimo-ws-metadata.version>
         <gson.version>2.3</gson.version>
-        <groovy.version>2.3.11</groovy.version>
         <mockwebserver.version>20130706</mockwebserver.version>
         <guava.version>18.0</guava.version>
-        <guava.osgi.version.clean>15.0</guava.osgi.version.clean>
         <hawtbuf.version>1.11</hawtbuf.version>
         <hawtdispatch.version>1.21</hawtdispatch.version>
-        <hawtio-dockerui.version>1.0.4</hawtio-dockerui.version>
-        <hawtio-kibana.version>3.1.0-SNAPSHOT</hawtio-kibana.version>
-        <hawtio-swagger.version>1.0.2</hawtio-swagger.version>
         <hawtio.version>1.4.51</hawtio.version>
         <hibernate-validator.version>5.1.3.Final</hibernate-validator.version>
         <httpclient.version>4.3.1</httpclient.version>
         <httpcomponents.version>4.0.2</httpcomponents.version>
-        <influxdb.version>1.2</influxdb.version>
-        <jackson.version>1.9.2</jackson.version>
         <jackson2.version>2.4.1</jackson2.version>
-        <jackson-module-scala.version>2.1.5_2</jackson-module-scala.version>
         <jansi.version>1.11</jansi.version>
         <jar.plugin.version>2.5</jar.plugin.version>
         <jasypt.version>1.9.2</jasypt.version>
         <javax.el-version>2.2.4</javax.el-version>
-        <jaxb-api.version>2.1</jaxb-api.version>
-        <jaxb.version>2.2.7</jaxb.version>
-        <jboss-javaee-6.version>1.0.0.Final</jboss-javaee-6.version>
         <jboss.forge.version>2.16.2.Final</jboss.forge.version>
         <!-- TODO is this always the same as drools.version? -->
-        <jbpm.version>6.1.0.CR1</jbpm.version>
         <jersey.version>1.18.1</jersey.version>
-        <jettison.version>1.3.7</jettison.version>
         <jetty-plugin-groupId>org.mortbay.jetty</jetty-plugin-groupId>
         <jetty-plugin.version>8.1.14.v20131031</jetty-plugin.version>
         <jetty.version>8.1.14.v20131031</jetty.version>
         <jetty9.version>9.1.5.v20140505</jetty9.version>
-        <jetty6.version>6.1.26_4</jetty6.version>
         <jgit.version>3.4.1.201406201815-r</jgit.version>
         <jolokia.version>1.3.1</jolokia.version>
         <jgroups.version>3.6.0.Final</jgroups.version>
@@ -167,51 +145,34 @@
         <lombok.version>1.14.4</lombok.version>
         <maven.version>3.1.1</maven.version>
         <maven.enforcer.plugin.version>1.3.1</maven.enforcer.plugin.version>
-        <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
         <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
         <maven.failsafe.plugin.version>2.18.1</maven.failsafe.plugin.version>
         <metrics.version>3.1.0</metrics.version>
-        <mina.version>2.0.7</mina.version>
         <mockserver.version>3.4</mockserver.version>
-        <mongo-java-driver.version>2.12.3</mongo-java-driver.version>
         <mvel.version>2.2.4.Final</mvel.version>
-        <netty.version>4.0.28.Final</netty.version>
         <openejb.container.version>4.7.1</openejb.container.version>
-        <openshift.client.groupId>com.openshift</openshift.client.groupId>
-        <openshift.client.version>2.7.0.Final</openshift.client.version>
         <osgi-compendium.version>4.3.1</osgi-compendium.version>
         <osgi-enterprise.version>5.0.0</osgi-enterprise.version>
-        <osgi-metadata.version>4.0.0.CR1</osgi-metadata.version>
         <osgi.version>5.0.0</osgi.version>
         <pax.url.version>2.1.0</pax.url.version>
         <qpid-jms.version>0.28</qpid-jms.version>
         <reflections.version>0.9.10</reflections.version>
         <resteasy.version>3.0.8.Final</resteasy.version>
-        <rhq-metrics.version>0.2.2.20140726-M3</rhq-metrics.version>
-        <rrd4j.version>2.0.7</rrd4j.version>
-        <serp.bundle.version>1.14.1_1</serp.bundle.version>
         <servlet-api.version>2.5</servlet-api.version>
         <servlet30-api.version>3.0.1</servlet30-api.version>
         <shrinkwrap-resolver.version>2.1.1</shrinkwrap-resolver.version>
-        <shrinkwrap.version>1.1.2</shrinkwrap.version>
-        <slf4j-api.version>1.7.12</slf4j-api.version>
         <slf4j.version>1.7.12</slf4j.version>
         <snakeyaml.version>1.5</snakeyaml.version>
         <spring.version>4.1.6.RELEASE</spring.version>
         <spring.boot.version>1.2.4.RELEASE</spring.boot.version>
         <sundrio.version>0.0.16</sundrio.version>
-        <swagger.version>1.3.2_1</swagger.version>
         <swagger.jaxrs.version>1.3.10</swagger.jaxrs.version>
-        <swagger-scala.version>2.10.2</swagger-scala.version>
         <tomcat-plugin.version>2.2</tomcat-plugin.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <vertx.version>2.1.5</vertx.version>
-        <wagon-webdav-plugin.version>1.0-beta-7</wagon-webdav-plugin.version>
         <weld.version>2.2.5.Final</weld.version>
         <wildfly.version>8.1.0.Final</wildfly.version>
         <zookeeper.version>3.4.6</zookeeper.version>
-        <!-- Disable OBR repository update by default -->
-        <obrRepository>NONE</obrRepository>
 
         <!-- OSGi bundles properties -->
         <fuse.osgi.bundle.name>${project.name}</fuse.osgi.bundle.name>
@@ -1408,8 +1369,8 @@
             </dependency>
 
             <dependency>
-               <groupId>com.google.guava</groupId>
-               <artifactId>guava</artifactId>
+              <groupId>com.google.guava</groupId>
+              <artifactId>guava</artifactId>
               <version>${guava.version}</version>
             </dependency>
 


### PR DESCRIPTION
This fix #4194 

The unused dependencies should now be removed. The introduction of a "bom" or parent/pom.xml still remain open and maybe can be subject of another issue.

Andrea