### PR TITLE
Removed metrics.version property because it was repeated, upgraded dropwizard metrics to version 3.1.2

### DIFF
--- a/components/fabric8-agent/pom.xml
+++ b/components/fabric8-agent/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
+            <version>${dropwizard-metrics.version}</version>
         </dependency>
 
         <dependency>

--- a/components/fabric8-apm/pom.xml
+++ b/components/fabric8-apm/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>${metrics.version}</version>
+      <version>${dropwizard-metrics.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <cxf.version>3.0.4</cxf.version>
         <deltaspike.version>1.0.3</deltaspike.version>
         <dnsjava.version>2.1.7</dnsjava.version>
-        <dropwizard-metrics.version>3.1.0</dropwizard-metrics.version>
+        <dropwizard-metrics.version>3.1.2</dropwizard-metrics.version>
         <elasticsearch.version>1.3.2</elasticsearch.version>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <fabric8.release.version>2.0.48</fabric8.release.version>
@@ -147,7 +147,6 @@
         <maven.enforcer.plugin.version>1.3.1</maven.enforcer.plugin.version>
         <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
         <maven.failsafe.plugin.version>2.18.1</maven.failsafe.plugin.version>
-        <metrics.version>3.1.0</metrics.version>
         <mockserver.version>3.4</mockserver.version>
         <mvel.version>2.2.4.Final</mvel.version>
         <openejb.container.version>4.7.1</openejb.container.version>


### PR DESCRIPTION
Hi,

I've removed a repeated property and upgrade the Metrics depedency to the latest version 3.1.2

Andrea