### PR TITLE
Fixes #4213 Upgrade to Jetty 9.2.0 - same version as in Camel 2.15.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <jetty-plugin-groupId>org.mortbay.jetty</jetty-plugin-groupId>
         <jetty-plugin.version>8.1.14.v20131031</jetty-plugin.version>
         <jetty.version>8.1.14.v20131031</jetty.version>
-        <jetty9.version>9.1.5.v20140505</jetty9.version>
+        <jetty9.version>9.2.10.v20150310</jetty9.version>
         <jgit.version>3.4.1.201406201815-r</jgit.version>
         <jolokia.version>1.3.1</jolokia.version>
         <jgroups.version>3.6.0.Final</jgroups.version>


### PR DESCRIPTION
This PR upgrades Jetty9 to the same version of Camel.2.15.x

Andrea