### PR TITLE
Fixes #4158 mvn fabric8:create-env should sort the env.properties file so they are easier to grok/edit

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
@@ -37,11 +37,13 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.maven.support.OrderedProperties;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteList;
 import io.fabric8.openshift.api.model.RouteSpec;
 import io.fabric8.utils.Files;
 import io.fabric8.utils.TablePrinter;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -98,7 +100,7 @@ public class CreateEnvMojo extends AbstractFabric8Mojo {
             }
             getProject().getProperties().setProperty(DOCKER_NAME, name);
             getProject().getProperties().setProperty(EXEC_ENV_SCRIPT, scriptFile.getAbsolutePath());
-            Properties envProperties = new Properties();
+            Properties envProperties = new OrderedProperties();
             Set<Map.Entry<String, String>> entries = env.entrySet();
             for (Map.Entry<String, String> entry : entries) {
                 String key = entry.getKey();

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/OrderedProperties.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/OrderedProperties.java
@@ -25,6 +25,7 @@ import java.util.Vector;
  */
 public class OrderedProperties extends Properties {
 
+	@Override
 	public Enumeration keys() {
 		Enumeration keysEnum = super.keys();
 		Vector<String> keyList = new Vector<String>();

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/OrderedProperties.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/OrderedProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2005-2015 Red Hat, Inc.                                    
+ *                                                                      
+ * Red Hat licenses this file to you under the Apache License, version  
+ * 2.0 (the "License"); you may not use this file except in compliance  
+ * with the License.  You may obtain a copy of the License at           
+ *                                                                      
+ *    http://www.apache.org/licenses/LICENSE-2.0                        
+ *                                                                      
+ * Unless required by applicable law or agreed to in writing, software  
+ * distributed under the License is distributed on an "AS IS" BASIS,    
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or      
+ * implied.  See the License for the specific language governing        
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.support;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.Vector;
+
+/**
+ * Properties class with ordering by key
+ */
+public class OrderedProperties extends Properties {
+
+	public Enumeration keys() {
+		Enumeration keysEnum = super.keys();
+		Vector<String> keyList = new Vector<String>();
+		while (keysEnum.hasMoreElements()) {
+			keyList.add((String) keysEnum.nextElement());
+		}
+		Collections.sort(keyList);
+		return keyList.elements();
+	}
+}

--- a/fabric8-maven-plugin/src/test/java/io/fabric8/maven/support/OrderedPropertiesTest.java
+++ b/fabric8-maven-plugin/src/test/java/io/fabric8/maven/support/OrderedPropertiesTest.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.maven.support;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+
+import org.junit.Test;
+
+/**
+ * Test the difference between Properties class and OrderedProperties class that extends the former 
+ */
+public class OrderedPropertiesTest {
+
+    @Test
+    public void testOrderedProperties() throws Exception {
+        Properties envProperties = new Properties();
+        envProperties.put("B", "value B");
+        envProperties.put("C", "value C");
+        envProperties.put("A", "value A");
+        envProperties.put("D", "value D");
+        envProperties.put("port", "8081");
+
+        Properties envOrdProperties = new OrderedProperties();
+        envOrdProperties.put("B", "value B");
+        envOrdProperties.put("C", "value C");
+        envOrdProperties.put("A", "value A");
+        envOrdProperties.put("D", "value D");
+        envOrdProperties.put("port", "8082");
+        envOrdProperties.put("host", "vagrant.local");
+
+        FileOutputStream fos = new FileOutputStream("./target/unordered.properties");
+        envProperties.store(fos, "Generated Unordered Environment Variables");
+        fos.close();
+
+        fos = new FileOutputStream("./target/ordered.properties");
+        envOrdProperties.store(fos, "Generated Ordered Environment Variables");
+        fos.close();
+
+        File orderedFile = new File("./target/ordered.properties");
+
+        assertThat(contentOf(orderedFile))
+            .startsWith("#Generated Ordered Environment Variables\n")
+            .containsSequence("A=value A\n","B=value B\n","C=value C\n","D=value D\n","host=vagrant.local\n")
+            .endsWith("port=8082\n");
+
+        File unorderedFile = new File("./target/unordered.properties");
+
+        assertThat(contentOf(unorderedFile))
+            .startsWith("#Generated Unordered Environment Variables\n")
+            .containsSequence("A=value A\n","port=8081\n","D=value D\n","C=value C\n")
+	        .endsWith("B=value B\n");
+
+        unorderedFile.deleteOnExit();
+        orderedFile.deleteOnExit();
+	}
+}


### PR DESCRIPTION
This PR fixes #4158. I will work on a BaseUnitTest with a running kubernetes in the next time.

Andrea 