### PR TITLE
Fixes #4056 mvn fabric8:create-env should output the docker command line to run the docker image

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/DockerCommandPlainPrint.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/DockerCommandPlainPrint.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2005-2015 Red Hat, Inc.                                    
+ *                                                                      
+ * Red Hat licenses this file to you under the Apache License, version  
+ * 2.0 (the "License"); you may not use this file except in compliance  
+ * with the License.  You may obtain a copy of the License at           
+ *                                                                      
+ *    http://www.apache.org/licenses/LICENSE-2.0                        
+ *                                                                      
+ * Unless required by applicable law or agreed to in writing, software  
+ * distributed under the License is distributed on an "AS IS" BASIS,    
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or      
+ * implied.  See the License for the specific language governing        
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.support;
+
+import java.util.Map;
+
+public class DockerCommandPlainPrint {
+
+    private static final String DOCKER_PREFIX_LOG_OUTPUT = "docker run -dP ";
+    
+    private StringBuilder dockerPlainTextCommand;
+
+	public DockerCommandPlainPrint(StringBuilder dockerPlainTextCommand) {
+		super();
+		this.dockerPlainTextCommand = dockerPlainTextCommand;
+		this.dockerPlainTextCommand.append(DOCKER_PREFIX_LOG_OUTPUT);
+	}
+
+	public StringBuilder getDockerPlainTextCommand() {
+		return dockerPlainTextCommand;
+	}
+
+	public void setDockerPlainTextCommand(StringBuilder dockerPlainTextCommand) {
+		this.dockerPlainTextCommand = dockerPlainTextCommand;
+	}
+	
+	public void appendParameters(Map<String, String> data, String flag) {
+		for (Map.Entry<String, String> entry : data.entrySet())
+		{
+			dockerPlainTextCommand.append(flag);
+		    dockerPlainTextCommand.append(" ");
+		    dockerPlainTextCommand.append(entry.getKey());
+		    dockerPlainTextCommand.append("=");
+		    dockerPlainTextCommand.append(entry.getValue());
+		    dockerPlainTextCommand.append(" ");
+		}
+	}
+	
+	public void appendImageName(String imageName) {
+		dockerPlainTextCommand.append(imageName);
+	}
+    
+}

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/IDockerCommandPlainPrintCostants.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/IDockerCommandPlainPrintCostants.java
@@ -1,0 +1,6 @@
+package io.fabric8.maven.support;
+
+public interface IDockerCommandPlainPrintCostants {
+
+	public final static String EXPRESSION_FLAG = "-e";
+}

--- a/fabric8-maven-plugin/src/test/java/io/fabric8/maven/support/DockerCommandPlainPrintTest.java
+++ b/fabric8-maven-plugin/src/test/java/io/fabric8/maven/support/DockerCommandPlainPrintTest.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.maven.support;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test the DockerCommandPlainPrint class
+ */
+public class DockerCommandPlainPrintTest {
+
+    @Test
+    public void testDockerCommandPlainPrintTest() throws Exception {
+        Map<String,String> env = new LinkedHashMap<String,String>();
+        env.put("FOO", "bar");
+        env.put("USER", "test");
+        env.put("PWD", "pass");
+        
+        StringBuilder sb = new StringBuilder();
+        DockerCommandPlainPrint plainPrint = new DockerCommandPlainPrint(sb);
+        plainPrint.appendParameters(env, IDockerCommandPlainPrintCostants.EXPRESSION_FLAG);
+        plainPrint.appendImageName("test/test_image");
+        
+        String expected = "docker run -dP -e FOO=bar -e USER=test -e PWD=pass test/test_image";
+        
+        assertThat(plainPrint.getDockerPlainTextCommand().toString()).isEqualTo(expected);
+
+	}
+}

--- a/fabric8-maven-plugin/src/test/java/io/fabric8/maven/support/JsonSchemaTest.java
+++ b/fabric8-maven-plugin/src/test/java/io/fabric8/maven/support/JsonSchemaTest.java
@@ -20,7 +20,6 @@ package io.fabric8.maven.support;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
This PR resolve the issue. Currently the docker run command logged contains only the environment variables. Anyway I'll work on adding volumes to the plain text Docker run command logged. I run some tests and work on the camel-servlet quickstart example. The output of mvn fabric8:create-env is the following

```
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Fabric8 :: Quickstarts :: War :: Camel Servlet 2.3-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- fabric8-maven-plugin:2.3-SNAPSHOT:create-env (default-cli) @ quickstart-war-camel-servlet ---
[INFO] 
[INFO] Generated Environment variables:
[INFO] -------------------------------
[INFO] [Name]                                       [Value]                      
[INFO] DOCKER_REGISTRY_SERVICE_HOST                 docker-registry.vagrant.local
[INFO] DOCKER_REGISTRY_SERVICE_PORT                 5000                         
[INFO] DOCKER_REGISTRY_SERVICE_PORT_5000_TCP_PROTO  TCP                          
[INFO] DOCKER_REGISTRY_TCP_PROTO                    TCP                          
[INFO] FABRIC8_SERVICE_HOST                         fabric8.vagrant.local        
[INFO] FABRIC8_SERVICE_PORT                         80                           
[INFO] FABRIC8_SERVICE_PORT_80_TCP_PROTO            TCP                          
[INFO] FABRIC8_TCP_PROTO                            TCP                          
[INFO] KUBERNETES_NAMESPACE                                                      
[INFO] KUBERNETES_RO_SERVICE_HOST                   172.30.0.1                   
[INFO] KUBERNETES_RO_SERVICE_PORT                   80                           
[INFO] KUBERNETES_RO_SERVICE_PORT_80_TCP_PROTO      TCP                          
[INFO] KUBERNETES_RO_TCP_PROTO                      TCP                          
[INFO] KUBERNETES_SERVICE_HOST                      172.30.0.2                   
[INFO] KUBERNETES_SERVICE_PORT                      443                          
[INFO] KUBERNETES_SERVICE_PORT_443_TCP_PROTO        TCP                          
[INFO] KUBERNETES_TCP_PROTO                         TCP                          
[INFO] ROUTER_SERVICE_HOST                          172.30.162.8                 
[INFO] ROUTER_SERVICE_PORT                          80                           
[INFO] ROUTER_SERVICE_PORT_80_TCP_PROTO             TCP                          
[INFO] ROUTER_TCP_PROTO                             TCP                          
[INFO] 
[INFO] Docker Run Command:
[INFO] -------------------------------
[INFO] docker run -dP -e DOCKER_REGISTRY_SERVICE_HOST=docker-registry.vagrant.local -e DOCKER_REGISTRY_SERVICE_PORT=5000 -e DOCKER_REGISTRY_SERVICE_PORT_5000_TCP_PROTO=TCP -e DOCKER_REGISTRY_TCP_PROTO=TCP -e FABRIC8_SERVICE_HOST=fabric8.vagrant.local -e FABRIC8_SERVICE_PORT=80 -e FABRIC8_SERVICE_PORT_80_TCP_PROTO=TCP -e FABRIC8_TCP_PROTO=TCP -e KUBERNETES_NAMESPACE=null -e KUBERNETES_RO_SERVICE_HOST=172.30.0.1 -e KUBERNETES_RO_SERVICE_PORT=80 -e KUBERNETES_RO_SERVICE_PORT_80_TCP_PROTO=TCP -e KUBERNETES_RO_TCP_PROTO=TCP -e KUBERNETES_SERVICE_HOST=172.30.0.2 -e KUBERNETES_SERVICE_PORT=443 -e KUBERNETES_SERVICE_PORT_443_TCP_PROTO=TCP -e KUBERNETES_TCP_PROTO=TCP -e ROUTER_SERVICE_HOST=172.30.162.8 -e ROUTER_SERVICE_PORT=80 -e ROUTER_SERVICE_PORT_80_TCP_PROTO=TCP -e ROUTER_TCP_PROTO=TCP fabric8/quickstart-war-camel-servlet:2.3-SNAPSHOT

```

Bye,
Andrea