### PR TITLE
Fixes #4159 mvn fabric8:create-env values with a space inside should be wrapped with "" when generating the export statement.

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
@@ -378,7 +378,11 @@ public class CreateEnvMojo extends AbstractFabric8Mojo {
         try (FileWriter writer = new FileWriter(scroptFile)) {
             writer.append("#!/bin/bash").append("\n");
             for (Map.Entry<String, String> entry: map.entrySet()) {
-                writer.append("export ").append(entry.getKey()).append("=").append(entry.getValue()).append("\n");
+            	if (entry.getValue() != null && !entry.getValue().contains(" ")) {
+                    writer.append("export ").append(entry.getKey()).append("=").append(entry.getValue()).append("\n");	
+            	} else {
+                    writer.append("export ").append(entry.getKey()).append("=").append("\"").append(entry.getValue()).append("\"").append("\n");
+            	}
             }
             writer.flush();
         }


### PR DESCRIPTION
Hi,

This PR resolves #4159.

Trying to put in the env map 

```
JAVA_OPTIONS=-Djavax.net.sslews.keyStorePassword=admin -Djavax.net.ssl.keyStorePassword=admin
```

produces the following output

```
#!/bin/bash
export DOCKER_REGISTRY_SERVICE_HOST=docker-registry.vagrant.f8
export DOCKER_REGISTRY_SERVICE_PORT=5000
export DOCKER_REGISTRY_SERVICE_PORT_5000_TCP_PROTO=TCP
export DOCKER_REGISTRY_TCP_PROTO=TCP
export ELASTICSEARCH_SERVICE_HOST=172.30.172.243
export ELASTICSEARCH_SERVICE_PORT=9200
export ELASTICSEARCH_SERVICE_PORT_9200_TCP_PROTO=TCP
export ELASTICSEARCH_TCP_PROTO=TCP
export FABRIC8_SERVICE_HOST=fabric8.vagrant.f8
export FABRIC8_SERVICE_PORT=80
export FABRIC8_SERVICE_PORT_80_TCP_PROTO=TCP
export FABRIC8_TCP_PROTO=TCP
export JAVA_OPTIONS="-Djavax.net.sslews.keyStorePassword=admin -Djavax.net.ssl.keyStorePassword=admin"
export KIBANA_SERVICE_HOST=kibana.vagrant.f8
export KIBANA_SERVICE_PORT=80
export KIBANA_SERVICE_PORT_80_TCP_PROTO=TCP
export KIBANA_TCP_PROTO=TCP
export KUBERNETES_NAMESPACE="null"
export KUBERNETES_RO_SERVICE_HOST=172.30.0.1
export KUBERNETES_RO_SERVICE_PORT=80
export KUBERNETES_RO_SERVICE_PORT_80_TCP_PROTO=TCP
export KUBERNETES_RO_TCP_PROTO=TCP
export KUBERNETES_SERVICE_HOST=172.30.0.2
export KUBERNETES_SERVICE_PORT=443
export KUBERNETES_SERVICE_PORT_443_TCP_PROTO=TCP
export KUBERNETES_TCP_PROTO=TCP
export ROUTER_SERVICE_HOST=172.30.35.209
export ROUTER_SERVICE_PORT=80
export ROUTER_SERVICE_PORT_80_TCP_PROTO=TCP
export ROUTER_TCP_PROTO=TCP
```