### PR TITLE
Fixes #4157 mvn fabric8:create-env should remove KUBERNETES_CLIENT_CERTIFICATE_FILE and KUBERNETES_CLIENT_KEY_FILE by default

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
@@ -32,6 +32,7 @@ import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.maven.support.DefaultExcludedEnvVariablesEnum;
 import io.fabric8.maven.support.DockerCommandPlainPrint;
 import io.fabric8.maven.support.IDockerCommandPlainPrintCostants;
 import io.fabric8.maven.support.OrderedProperties;
@@ -47,6 +48,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -98,6 +100,7 @@ public class CreateEnvMojo extends AbstractFabric8Mojo {
             Map<String, String> env = getEnvFromConfig(list);
             String namespace = getNamespace();
             env.putAll(getNamespaceServiceEnv(namespace));
+            removeDefaultEnv(env);
             displayEnv(env);
 
             if (name == null) {
@@ -335,6 +338,15 @@ public class CreateEnvMojo extends AbstractFabric8Mojo {
         }
         getLog().info("");
 
+    }
+    
+    private void removeDefaultEnv(Map<String, String> map) {
+        for(Iterator<Map.Entry<String, String>> it = map.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<String, String> entry = it.next();
+            if(DefaultExcludedEnvVariablesEnum.contains(entry.getKey())) {
+                it.remove();
+            }
+        }
     }
     
     private void displayDockerRunCommand(DockerCommandPlainPrint dockerCommandPlainPrint) {

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/DefaultExcludedEnvVariablesEnum.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/DefaultExcludedEnvVariablesEnum.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2005-2015 Red Hat, Inc.                                    
+ *                                                                      
+ * Red Hat licenses this file to you under the Apache License, version  
+ * 2.0 (the "License"); you may not use this file except in compliance  
+ * with the License.  You may obtain a copy of the License at           
+ *                                                                      
+ *    http://www.apache.org/licenses/LICENSE-2.0                        
+ *                                                                      
+ * Unless required by applicable law or agreed to in writing, software  
+ * distributed under the License is distributed on an "AS IS" BASIS,    
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or      
+ * implied.  See the License for the specific language governing        
+ * permissions and limitations under the License.
+ */
+package io.fabric8.maven.support;
+
+public enum DefaultExcludedEnvVariablesEnum {
+    KUBERNETES_NAMESPACE  ("KUBERNETES_NAMESPACE"), 
+    KUBERNETES_CLIENT_CERTIFICATE_FILE ("KUBERNETES_CLIENT_CERTIFICATE_FILE"), 
+    KUBERNETES_CLIENT_KEY_FILE   ("KUBERNETES_CLIENT_KEY_FILE"),
+    KUBERNETES_RO_SERVICE_HOST ("KUBERNETES_RO_SERVICE_HOST"),
+    KUBERNETES_RO_SERVICE_PORT ("KUBERNETES_RO_SERVICE_PORT"),
+    KUBERNETES_RO_SERVICE_PORT_80_TCP_PROTO ("KUBERNETES_RO_SERVICE_PORT_80_TCP_PROTO"),
+    KUBERNETES_SERVICE_HOST ("KUBERNETES_SERVICE_HOST"),
+    KUBERNETES_SERVICE_PORT ("KUBERNETES_SERVICE_PORT"),
+    KUBERNETES_SERVICE_PORT_443_TCP_PROTO ("KUBERNETES_SERVICE_PORT_443_TCP_PROTO");
+    
+    private final String envVariable;
+
+    DefaultExcludedEnvVariablesEnum(String envVariable) {
+        this.envVariable = envVariable;
+    }
+    
+    public static boolean contains(String test) {
+        for (DefaultExcludedEnvVariablesEnum c : DefaultExcludedEnvVariablesEnum.values()) {
+            if (c.name().equals(test)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Hi,

This PR fixes #4157.

I've tested the code with the camel-servlet quickstart example:

https://github.com/fabric8io/quickstarts/tree/master/quickstarts/war/camel-servlet

And I get the following output with mvn fabric8:create-env:

```
> mvn fabric8:create-env
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Fabric8 :: Quickstarts :: War :: Camel Servlet 2.3-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- fabric8-maven-plugin:2.3-SNAPSHOT:create-env (default-cli) @ quickstart-war-camel-servlet ---
[INFO] 
[INFO] Generated Environment variables:
[INFO] -------------------------------
[INFO] [Name]                                       [Value]                   
[INFO] DOCKER_REGISTRY_SERVICE_HOST                 docker-registry.vagrant.f8
[INFO] DOCKER_REGISTRY_SERVICE_PORT                 5000                      
[INFO] DOCKER_REGISTRY_SERVICE_PORT_5000_TCP_PROTO  TCP                       
[INFO] DOCKER_REGISTRY_TCP_PROTO                    TCP                       
[INFO] ELASTICSEARCH_SERVICE_HOST                   172.30.83.169             
[INFO] ELASTICSEARCH_SERVICE_PORT                   9200                      
[INFO] ELASTICSEARCH_SERVICE_PORT_9200_TCP_PROTO    TCP                       
[INFO] ELASTICSEARCH_TCP_PROTO                      TCP                       
[INFO] FABRIC8_SERVICE_HOST                         fabric8.vagrant.f8        
[INFO] FABRIC8_SERVICE_PORT                         80                        
[INFO] FABRIC8_SERVICE_PORT_80_TCP_PROTO            TCP                       
[INFO] FABRIC8_TCP_PROTO                            TCP                       
[INFO] KIBANA_SERVICE_HOST                          kibana.vagrant.f8         
[INFO] KIBANA_SERVICE_PORT                          80                        
[INFO] KIBANA_SERVICE_PORT_80_TCP_PROTO             TCP                       
[INFO] KIBANA_TCP_PROTO                             TCP                       
[INFO] KUBERNETES_RO_TCP_PROTO                      TCP                       
[INFO] KUBERNETES_TCP_PROTO                         TCP                       
[INFO] ROUTER_SERVICE_HOST                          172.30.169.42             
[INFO] ROUTER_SERVICE_PORT                          80                        
[INFO] ROUTER_SERVICE_PORT_80_TCP_PROTO             TCP                       
[INFO] ROUTER_TCP_PROTO                             TCP                       
[INFO] 
[INFO] Docker Run Command:
[INFO] -------------------------------
[INFO] docker run -dP -e DOCKER_REGISTRY_SERVICE_HOST=docker-registry.vagrant.f8 -e DOCKER_REGISTRY_SERVICE_PORT=5000 -e DOCKER_REGISTRY_SERVICE_PORT_5000_TCP_PROTO=TCP -e DOCKER_REGISTRY_TCP_PROTO=TCP -e ELASTICSEARCH_SERVICE_HOST=172.30.83.169 -e ELASTICSEARCH_SERVICE_PORT=9200 -e ELASTICSEARCH_SERVICE_PORT_9200_TCP_PROTO=TCP -e ELASTICSEARCH_TCP_PROTO=TCP -e FABRIC8_SERVICE_HOST=fabric8.vagrant.f8 -e FABRIC8_SERVICE_PORT=80 -e FABRIC8_SERVICE_PORT_80_TCP_PROTO=TCP -e FABRIC8_TCP_PROTO=TCP -e KIBANA_SERVICE_HOST=kibana.vagrant.f8 -e KIBANA_SERVICE_PORT=80 -e KIBANA_SERVICE_PORT_80_TCP_PROTO=TCP -e KIBANA_TCP_PROTO=TCP -e KUBERNETES_RO_TCP_PROTO=TCP -e KUBERNETES_TCP_PROTO=TCP -e ROUTER_SERVICE_HOST=172.30.169.42 -e ROUTER_SERVICE_PORT=80 -e ROUTER_SERVICE_PORT_80_TCP_PROTO=TCP -e ROUTER_TCP_PROTO=TCP -p 8080 -p 8778 fabric8/quickstart-war-camel-servlet:2.3-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.734 s
[INFO] Finished at: 2015-06-30T21:08:39+02:00
[INFO] Final Memory: 23M/215M
[INFO] ------------------------------------------------------------------------
```

Bye.

Andrea