### PR TITLE
Fix #4375 mvn fabric8:create-env should output volumes, ports the same way we do with env variables

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/CreateEnvMojo.java
@@ -114,6 +114,9 @@ public class CreateEnvMojo extends AbstractFabric8Mojo {
             dockerCommandPlainPrint.appendContainerPorts(containerPort, IDockerCommandPlainPrintCostants.PORT_FLAG);
             dockerCommandPlainPrint.appendVolumeMounts(volumeMount, IDockerCommandPlainPrintCostants.VOLUME_FLAG);
             dockerCommandPlainPrint.appendImageName(name);
+            
+            displayVolumes(volumeMount);
+            displayContainerPorts(containerPort);
             displayDockerRunCommand(dockerCommandPlainPrint);
 
             Properties properties = getProject().getProperties();
@@ -330,6 +333,65 @@ public class CreateEnvMojo extends AbstractFabric8Mojo {
 
         getLog().info("");
         getLog().info("Generated Environment variables:");
+        getLog().info("-------------------------------");
+
+        List<String> lines = table.asTextLines();
+        for (String line : lines) {
+            getLog().info(line);
+        }
+        getLog().info("");
+
+    }
+    
+    private void displayVolumes(List<VolumeMount> volumeMount) {
+        TablePrinter table = new TablePrinter();
+        table.columns("Name", "Mount Path", "Read Only");
+
+		Iterator<VolumeMount> it = volumeMount.iterator();
+		while (it.hasNext()){
+			VolumeMount vol = it.next();
+            String name = vol.getName();
+            String mounthPath = vol.getMountPath();
+            String ro = String.valueOf(Boolean.FALSE);
+            if (vol.getReadOnly() == true) {
+            	ro = String.valueOf(Boolean.TRUE);
+            }
+			table.row(name, mounthPath, ro);
+		}
+
+        getLog().info("");
+        getLog().info("Volumes Summary:");
+        getLog().info("-------------------------------");
+
+        List<String> lines = table.asTextLines();
+        for (String line : lines) {
+            getLog().info(line);
+        }
+        getLog().info("");
+
+    }
+    
+    private void displayContainerPorts(List<ContainerPort> containerPort) {
+        TablePrinter table = new TablePrinter();
+        table.columns("Host IP", "Host Port", "Container Port");
+
+		Iterator<ContainerPort> it = containerPort.iterator();
+		while (it.hasNext()){
+			ContainerPort port = it.next();
+            String hostIp = port.getHostIP();
+            String hostPort = "";
+            String contPort = "";
+            if (port.getHostPort() != null) {
+            	hostPort = String.valueOf(port.getHostPort());
+            }
+            if (port.getContainerPort() != null) {
+            	contPort = String.valueOf(port.getContainerPort());
+            }
+			table.row(hostIp, hostPort, contPort);
+		}
+
+        getLog().info("");
+        getLog().info("Container Ports Summary:");
         getLog().info("-------------------------------");
 
         List<String> lines = table.asTextLines();


### PR DESCRIPTION
Hi,

This PR fixes #4375.

I've tested the code with the camel-servlet quickstart and I get the following output:

```
> mvn fabric8:create-env
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building Fabric8 :: Quickstarts :: War :: Camel Servlet 2.3-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- fabric8-maven-plugin:2.3-SNAPSHOT:create-env (default-cli) @ quickstart-war-camel-servlet ---
[INFO] 
[INFO] Generated Environment variables:
[INFO] -------------------------------
[INFO] [Name]                                       [Value]                   
[INFO] DOCKER_REGISTRY_SERVICE_HOST                 docker-registry.vagrant.f8
[INFO] DOCKER_REGISTRY_SERVICE_PORT                 5000                      
[INFO] DOCKER_REGISTRY_SERVICE_PORT_5000_TCP_PROTO  TCP                       
[INFO] DOCKER_REGISTRY_TCP_PROTO                    TCP                       
[INFO] ELASTICSEARCH_SERVICE_HOST                   172.30.4.177              
[INFO] ELASTICSEARCH_SERVICE_PORT                   9200                      
[INFO] ELASTICSEARCH_SERVICE_PORT_9200_TCP_PROTO    TCP                       
[INFO] ELASTICSEARCH_TCP_PROTO                      TCP                       
[INFO] FABRIC8_SERVICE_HOST                         fabric8.vagrant.f8        
[INFO] FABRIC8_SERVICE_PORT                         80                        
[INFO] FABRIC8_SERVICE_PORT_80_TCP_PROTO            TCP                       
[INFO] FABRIC8_TCP_PROTO                            TCP                       
[INFO] KIBANA_SERVICE_HOST                          kibana.vagrant.f8         
[INFO] KIBANA_SERVICE_PORT                          80                        
[INFO] KIBANA_SERVICE_PORT_80_TCP_PROTO             TCP                       
[INFO] KIBANA_TCP_PROTO                             TCP                       
[INFO] KUBERNETES_RO_TCP_PROTO                      TCP                       
[INFO] KUBERNETES_TCP_PROTO                         TCP                       
[INFO] ROUTER_SERVICE_HOST                          172.30.9.166              
[INFO] ROUTER_SERVICE_PORT                          80                        
[INFO] ROUTER_SERVICE_PORT_80_TCP_PROTO             TCP                       
[INFO] ROUTER_TCP_PROTO                             TCP                       
[INFO] 
[INFO] 
[INFO] Volumes Summary:
[INFO] -------------------------------
[INFO] [Name]  [Mount Path]  [Read Only]
[INFO] 
[INFO] 
[INFO] Container Ports Summary:
[INFO] -------------------------------
[INFO] [Host IP]  [Host Port]  [Container Port]
[INFO]                         8080            
[INFO]                         8778            
[INFO] 
[INFO] Docker Run Command:
[INFO] -------------------------------
[INFO] docker run -dP -e DOCKER_REGISTRY_SERVICE_HOST=docker-registry.vagrant.f8 -e DOCKER_REGISTRY_SERVICE_PORT=5000 -e DOCKER_REGISTRY_SERVICE_PORT_5000_TCP_PROTO=TCP -e DOCKER_REGISTRY_TCP_PROTO=TCP -e ELASTICSEARCH_SERVICE_HOST=172.30.4.177 -e ELASTICSEARCH_SERVICE_PORT=9200 -e ELASTICSEARCH_SERVICE_PORT_9200_TCP_PROTO=TCP -e ELASTICSEARCH_TCP_PROTO=TCP -e FABRIC8_SERVICE_HOST=fabric8.vagrant.f8 -e FABRIC8_SERVICE_PORT=80 -e FABRIC8_SERVICE_PORT_80_TCP_PROTO=TCP -e FABRIC8_TCP_PROTO=TCP -e KIBANA_SERVICE_HOST=kibana.vagrant.f8 -e KIBANA_SERVICE_PORT=80 -e KIBANA_SERVICE_PORT_80_TCP_PROTO=TCP -e KIBANA_TCP_PROTO=TCP -e KUBERNETES_RO_TCP_PROTO=TCP -e KUBERNETES_TCP_PROTO=TCP -e ROUTER_SERVICE_HOST=172.30.9.166 -e ROUTER_SERVICE_PORT=80 -e ROUTER_SERVICE_PORT_80_TCP_PROTO=TCP -e ROUTER_TCP_PROTO=TCP -p 8080 -p 8778 fabric8/quickstart-war-camel-servlet:2.3-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.700 s
[INFO] Finished at: 2015-07-01T22:14:49+02:00
[INFO] Final Memory: 23M/215M
[INFO] ------------------------------------------------------------------------
```

Bye,
Andrea