### PR TITLE
Upgrade Maven compiler plugin to version 3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <commons-io2.version>2.4</commons-io2.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <compiler.plugin.version>3.2</compiler.plugin.version>
+        <compiler.plugin.version>3.3</compiler.plugin.version>
         <curator.version>2.8.0</curator.version>
         <cxf.version>3.0.4</cxf.version>
         <deltaspike.version>1.0.3</deltaspike.version>


### PR DESCRIPTION
Hi,

This PR upgrades maven-compiler-plugin to version 3.3.

Andrea