### PR TITLE
Fixes #4404 Camel-tests Forge addons: The furnace container cdi artifact is using a wrong version

### DIFF
--- a/forge/addons/camel-tests/pom.xml
+++ b/forge/addons/camel-tests/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.jboss.forge.furnace.container</groupId>
       <artifactId>cdi</artifactId>
-      <version>${jboss.forge.version}</version>
+      <version>${furnace.version}</version>
       <classifier>forge-addon</classifier>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Hi,

This PR resolves #4404.

Andrea