### PR TITLE
lets use 'revision' as a maven property for volumes of type gitRepo to match the generated json and k8s model property name

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/VolumeType.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/VolumeType.java
@@ -123,7 +123,7 @@ public enum VolumeType {
     private static final String VOLUME_NAME_PREFIX = VOLUME_PREFIX + ".%s";
     private static final String VOLUME_PROPERTY = VOLUME_NAME_PREFIX + ".%s";
     
-    private static final String VOLUME_GIT_REV = "gitRevision";
+    private static final String VOLUME_GIT_REV = "revision";
     private static final String VOLUME_SECRET_NAME = "secret";
 
     private static final String VOLUME_NFS_SERVER = "nfsServer";


### PR DESCRIPTION
lets use 'revision' as a maven property for volumes of type gitRepo to match the generated json and k8s model property name