### PR TITLE
Fixed Apache Karaf features descriptor

### DIFF
--- a/components/karaf-features/src/main/resources/features.xml
+++ b/components/karaf-features/src/main/resources/features.xml
@@ -45,10 +45,15 @@
     <bundle>mvn:javax.validation/validation-api/${validation-api.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson2.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson2.version}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2.version}</bundle>
     <bundle>mvn:io.fabric8/fabric8-utils/${project.version}</bundle>
     <bundle>mvn:commons-lang/commons-lang/${commons-lang.version}</bundle>
+    <bundle>mvn:com.ning/async-http-client/${ning.http-client.version}</bundle>
+    <bundle>wrap:mvn:dnsjava/dnsjava/${dnsjava.version}$overwrite=merge&amp;Import-Package=android.os;resolution:=optional,sun.net.spi.nameservice;resolution:=optional,*</bundle>
     <bundle>wrap:mvn:org.yaml/snakeyaml/${snakeyaml.version}</bundle>
     <bundle>wrap:mvn:org.json/json/${json.version}</bundle>
+    <bundle>wrap:mvn:io.fabric8/kubernetes-client/${kubernetes-client.version}</bundle>
+    <bundle>mvn:io.fabric8/kubernetes-model/${kubernetes-model.version}</bundle>
     <bundle>mvn:io.fabric8/kubernetes-api/${project.version}</bundle>
     
   </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
         <weld.version>2.2.14.Final</weld.version>
         <wildfly.version>8.2.0.Final</wildfly.version>
         <zookeeper.version>3.4.6</zookeeper.version>
+        <ning.http-client.version>1.9.29</ning.http-client.version>
 
         <!-- OSGi bundles properties -->
         <fuse.osgi.bundle.name>${project.name}</fuse.osgi.bundle.name>


### PR DESCRIPTION
Currently Fabric8 Karaf features descriptor is not installable due to the unresolved constraint errors. This patch adds required dependencies to features descriptor. Please note special handling of `dnsjava` dependency as a consequence of https://sourceforge.net/p/dnsjava/patches/23/.