### PR TITLE
Changed Contributing.md links to fabric8 FAQ and Community pages.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -88,8 +88,8 @@ license your work under the terms of the [Apache License](license.txt)
 
 # Additional Resources
 
-* [fabric8 FAQ](/faq/index.html)
+* [fabric8 FAQ](http://fabric8.io/faq/index.html)
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub create pull request documentation](https://help.github.com/articles/creating-a-pull-request)
-* [join the fabric8 community](/community/index.html)
+* [join the fabric8 community](http://fabric8.io/community/index.html)
 


### PR DESCRIPTION
I thought those links should refer back to the fabric8.io site (since the previous links were broken, pointing to a missing .md page inside this repo).