### PR TITLE
Resolves #4612 Fabric8-maven-plugin: ObjectMapper reader(java.lang.Cl…

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/JsonSchemas.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/support/JsonSchemas.java
@@ -75,19 +75,19 @@ public class JsonSchemas {
     }
 
     public static JsonSchema loadSchema(URL url) throws IOException {
-        return objectMapper.reader(JsonSchema.class).readValue(url);
+        return objectMapper.readerFor(JsonSchema.class).readValue(url);
     }
 
     public static JsonSchema loadSchema(File file) throws IOException {
-        return objectMapper.reader(JsonSchema.class).readValue(file);
+        return objectMapper.readerFor(JsonSchema.class).readValue(file);
     }
 
     public static JsonSchema loadSchema(InputStream inputStream) throws IOException {
-        return objectMapper.reader(JsonSchema.class).readValue(inputStream);
+        return objectMapper.readerFor(JsonSchema.class).readValue(inputStream);
     }
 
     public static JsonSchema loadSchema(byte[] data) throws IOException {
-        return objectMapper.reader(JsonSchema.class).readValue(data);
+        return objectMapper.readerFor(JsonSchema.class).readValue(data);
     }
 
     /**


### PR DESCRIPTION
…ass<?>) method is deprecated, replace it with readerFor (java.lang.Class<?>)

This PR fixes #4612 

Andrea