### PR TITLE
Related to #4612 Fabric8-maven-plugin: ObjectMapper reader(java.lang.…

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
@@ -452,7 +452,7 @@ public final class KubernetesHelper {
      */
     public static Object loadJson(byte[] json) throws IOException {
         if (json != null && json.length > 0) {
-            return OBJECT_MAPPER.reader(KubernetesResource.class).readValue(json);
+            return OBJECT_MAPPER.readerFor(KubernetesResource.class).readValue(json);
         }
         return null;
     }


### PR DESCRIPTION
…Class<?>) method is deprecated, replace it with readerFor (java.lang.Class<?>)

There was one occurrence of reader inside Kubernetes-api component.