### PR TITLE
Resolves #4622 Kubernetes-api: writerWithType(java.lang.Class<?>) in …

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
@@ -414,7 +414,7 @@ public final class KubernetesHelper {
 
     public static String toJson(Object dto) throws JsonProcessingException {
         Class<?> clazz = dto.getClass();
-        return OBJECT_MAPPER.writerWithType(clazz).writeValueAsString(dto);
+        return OBJECT_MAPPER.writerFor(clazz).writeValueAsString(dto);
     }
 
     /**

--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/extensions/Templates.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/extensions/Templates.java
@@ -217,7 +217,7 @@ public class Templates {
                     json = Strings.replaceAllWithoutRegex(json, regex, value);
                 }
             }
-            return  OBJECT_MAPPER.reader(KubernetesList.class).readValue(json);
+            return  OBJECT_MAPPER.readerFor(KubernetesList.class).readValue(json);
         } else {
             KubernetesList answer = new KubernetesList();
             answer.setItems(objects);

--- a/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/ParseExamplesTest.java
+++ b/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/ParseExamplesTest.java
@@ -99,7 +99,7 @@ public class ParseExamplesTest {
     public static <T> T assertParseExampleFile(String fileName, Class<T> clazz) throws Exception {
         File exampleFile = new File(getKubernetesExamplesDir(), fileName);
         assertFileExists(exampleFile);
-        T answer = OBJECT_MAPPER.reader(clazz).readValue(exampleFile);
+        T answer = OBJECT_MAPPER.readerFor(clazz).readValue(exampleFile);
         assertNotNull("Null returned while unmarshalling " + exampleFile, answer);
         LOG.info("Parsed: " + fileName + " as: " + answer);
         return answer;

--- a/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/ParseTest.java
+++ b/components/kubernetes-api/src/test/java/io/fabric8/kubernetes/api/ParseTest.java
@@ -128,7 +128,7 @@ public class ParseTest {
     public static <T> T assertParseExampleFile(String fileName, Class<T> clazz) throws Exception {
         File exampleFile = new File(getKubernetesExamplesDir(), fileName);
         assertFileExists(exampleFile);
-        Object answer = OBJECT_MAPPER.reader(clazz).readValue(exampleFile);
+        Object answer = OBJECT_MAPPER.readerFor(clazz).readValue(exampleFile);
         assertNotNull("Null returned while unmarshalling " + exampleFile, answer);
         LOG.info("Parsed: " + fileName + " as: " + answer);
         assertTrue("Is not an instance of " + clazz.getSimpleName() + " was: "+ answer.getClass().getName(), clazz.isInstance(answer));


### PR DESCRIPTION
…com.fasterxml.jackson.databind.ObjectMapper has been deprecated

This resolves #4622 and remove the last occurrences of reader related to #4612 

Andrea