### PR TITLE
lets default to the ChromeDriver by default as HtmlUnit doesn't seem to handle the OAuth redirects properly

### DIFF
--- a/components/fabric8-selenium/src/main/java/io/fabric8/selenium/SeleniumTests.java
+++ b/components/fabric8-selenium/src/main/java/io/fabric8/selenium/SeleniumTests.java
@@ -104,7 +104,7 @@ public class SeleniumTests {
                 return new HtmlUnitDriver();
             }
         }
-        return new HtmlUnitDriver();
+        return new ChromeDriver();
     }
 
     public static void logError(String message, Throwable e) {


### PR DESCRIPTION
lets default to the ChromeDriver by default as HtmlUnit doesn't seem to handle the OAuth redirects properly