### PR TITLE
#4882: Arquillain configuration now falls back to clients defaults (s…

### DIFF
--- a/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/kubernetes/Configuration.java
+++ b/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/kubernetes/Configuration.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.arquillian.kubernetes;
 
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.internal.Utils;
 import io.fabric8.utils.Strings;
 
@@ -53,6 +55,8 @@ import static io.fabric8.arquillian.kubernetes.Constants.WAIT_POLL_INTERVAL;
 import static io.fabric8.arquillian.kubernetes.Constants.WAIT_TIMEOUT;
 
 public class Configuration {
+
+    private static final Config FALLBACK_CONFIG = new ConfigBuilder().build();
 
     private String masterUrl;
     private List<String> environmentDependencies = new ArrayList<>();
@@ -155,7 +159,7 @@ public class Configuration {
     public static Configuration fromMap(Map<String, String> map) {
         Configuration configuration = new Configuration();
         try {
-            configuration.masterUrl = getStringProperty(KUBERNETES_MASTER, map, DEFAULT_KUBERNETES_MASTER);
+            configuration.masterUrl = getStringProperty(KUBERNETES_MASTER, map, FALLBACK_CONFIG.getMasterUrl());
             configuration.environmentInitEnabled = getBooleanProperty(ENVIRONMENT_INIT_ENABLED, map, true);
             configuration.environmentConfigUrl = getKubernetesConfigurationUrl(map);
             configuration.environmentDependencies = Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), " ");

--- a/components/fabric8-arquillian/src/test/java/io/fabric8/arquillian/kubernetes/ConfigurationTest.java
+++ b/components/fabric8-arquillian/src/test/java/io/fabric8/arquillian/kubernetes/ConfigurationTest.java
@@ -16,6 +16,8 @@
 
 package io.fabric8.arquillian.kubernetes;
 
+import io.fabric8.kubernetes.client.Config;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -73,6 +75,11 @@ public class ConfigurationTest {
         System.getProperties().remove(GOFABRIC8_ENABLED);
     }
 
+    @After
+    public void tearDown() {
+        setUp();
+    }
+
     @Test
     public void testWithConfigMap() {
         String expctedMaster = "http://expected.master:80";
@@ -125,7 +132,17 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testConfigWithSystemProperteis() {
+    public void testFallbackToClientsDefaults() {
+        //Let's provide a fake kubeconfig for the client.
+        System.setProperty(Config.KUBERNETES_KUBECONFIG_FILE, getClass().getResource("/test-kubeconfig").getFile());
+        Configuration config = Configuration.fromMap(new HashMap<String, String>());
+        assertNotNull(config);
+
+        assertEquals("https://from.kube.config:8443/", config.getMasterUrl());
+    }
+
+    @Test
+    public void testConfigWithSystemProperties() {
         String expctedMaster = "http://expected.master:80";
         String expectedNamespace = "expected.namespace";
         String expectedDomain = "expected.domain";
@@ -176,7 +193,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testConfigWithSystemProperteisAndConfigMap() {
+    public void testConfigWithSystemPropertiesAndConfigMap() {
         String expctedMaster = "http://expected.master:80";
         String expectedNamespace = "expected.namespace";
         String expectedDomain = "expected.domain";

--- a/components/fabric8-arquillian/src/test/resources/test-kubeconfig
+++ b/components/fabric8-arquillian/src/test/resources/test-kubeconfig
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://from.kube.config:8443
+  name: 172-28-128-4:8443
+contexts:
+- context:
+    cluster: 172-28-128-4:8443
+    namespace: testns
+    user: user/172-28-128-4:8443
+  name: testns/172-28-128-4:8443/user
+current-context: testns/172-28-128-4:8443/user
+kind: Config
+preferences: {}
+users:
+- name: user/172-28-128-4:8443
+  user:
+    token: token


### PR DESCRIPTION
…ervice account < kubeconfig < env var < system props), if a value hasn't been explicitly specified in arquillian.xml. Add unit test for that particular case. Fix typos in test case names.