### PR TITLE
Include .sh in the archetype builder as we supply sometimes those in …

### DIFF
--- a/tooling/archetype-builder/src/main/java/io/fabric8/tooling/archetype/builder/ArchetypeBuilder.java
+++ b/tooling/archetype-builder/src/main/java/io/fabric8/tooling/archetype/builder/ArchetypeBuilder.java
@@ -75,6 +75,7 @@ public class ArchetypeBuilder {
         "md",
         "properties",
         "scala",
+        "sh",   /* sometimes we have .sh scripts in src/test/resources */
         "ssp",
         "ts",
         "txt",


### PR DESCRIPTION
…the quickstarts for testing etc.