### PR TITLE
Harmonize environment variables in run script

### DIFF
--- a/hawt-app-maven-plugin/readme.md
+++ b/hawt-app-maven-plugin/readme.md
@@ -29,9 +29,9 @@ which main class to use.  For example:
 To create the app as part of you default build for the module, add the a plugin configuration similar to the following in your maven module:
 
     <plugin>
-      <groupId>org.jboss.hawt.app</groupId>
+      <groupId>io.fabric8</groupId>
       <artifactId>hawt-app-maven-plugin</artifactId>
-      <version>1.2</version>
+      <version>2.2.44</version>
       <executions>
         <execution>
           <goals>
@@ -72,6 +72,7 @@ JAVA_ENABLE_DEBUG | If set to true, then enables JVM debugging
 JAVA_DEBUG_PORT | Port used for debugging (default: 5005)
 JAVA_AGENT | Set this to pass any JVM agent arguments for stuff like profilers
 JAVA_MAIN_ARGS | Arguments that will be passed to you application's main method.  **Default:** the arguments passed to the `bin/run` script.
+JAVA_MAIN_CLASS | The main class to use if not configured within the plugin
 
 Runtime Defaults Configuration
 ------------------------------

--- a/hawt-app-maven-plugin/readme.md
+++ b/hawt-app-maven-plugin/readme.md
@@ -29,9 +29,9 @@ which main class to use.  For example:
 To create the app as part of you default build for the module, add the a plugin configuration similar to the following in your maven module:
 
     <plugin>
-      <groupId>io.fabric8</groupId>
+      <groupId>org.jboss.hawt.app</groupId>
       <artifactId>hawt-app-maven-plugin</artifactId>
-      <version>2.2.44</version>
+      <version>1.2</version>
       <executions>
         <execution>
           <goals>
@@ -62,15 +62,16 @@ source | hawt-app.source | If this directory exists, then it's contents are used
 Env Configuration Options
 -------------------------
 
-There are several environment variables that can be set before running the `bin\run` script to customize your app's startup.  
+There are several environment variables that can be set before running the `bin/run` script to customize your app's startup.  
 
 Environment Variable | Description
 -------------------- | -----------
-JVM_ARGS | Options that will be passed to the JVM.  Use it to set options like the max JVM memory (-Xmx1G).
-JVM_DEBUG_ARGS | JVM debug arguments
-JVM_DEBUG | If set to true, then enables JVM debug on port 5005
-JVM_AGENT | Set this to pass any JVM agent arguments for stuff like profilers
-MAIN_ARGS | Arguments that will be passed to you application's main method.  **Default:** the arguments passed to the `bin/run` script.
+JAVA_APP_DIR | Directory holding the application (default: parent directory of the run script)
+JAVA_OPTIONS | Options that will be passed to the JVM.  Use it to set options like the max JVM memory (-Xmx1G).
+JAVA_ENABLE_DEBUG | If set to true, then enables JVM debugging  
+JAVA_DEBUG_PORT | Port used for debugging (default: 5005)
+JAVA_AGENT | Set this to pass any JVM agent arguments for stuff like profilers
+JAVA_MAIN_ARGS | Arguments that will be passed to you application's main method.  **Default:** the arguments passed to the `bin/run` script.
 
 Runtime Defaults Configuration
 ------------------------------
@@ -80,7 +81,7 @@ all the environment variables if you wish.  You can additionally also modify the
 
 Environment Variable | Description
 -------------------- | -----------
-MAIN | The main class that will be executed.
-APP | The name of this app, if supported by your system this will be displayed as the process name. **Default:** *${project.artifactId}*
-CLASSPATH | The classpath of the java application
+JAVA_MAIN_CLASS | The main class that will be executed.
+JAVA_APP_NAME | The name of this app, if supported by your system this will be displayed as the process name. **Default:** *${project.artifactId}*
+JAVA_CLASSPATH | The classpath of the java application
 

--- a/hawt-app-maven-plugin/src/main/java/io/fabric8/maven/hawt/app/BuildMojo.java
+++ b/hawt-app-maven-plugin/src/main/java/io/fabric8/maven/hawt/app/BuildMojo.java
@@ -144,7 +144,7 @@ public class BuildMojo extends AbstractDependencyFilterMojo {
         }
 
         // Finally lets write the classpath.
-        String classpathTxt = StringUtils.join(classpath.iterator(), "\r\n")+"\r\n";
+        String classpathTxt = StringUtils.join(classpath.iterator(), "\n")+"\n";
         try {
             FileUtils.fileWrite(new File(libDir, ".classpath"), classpathTxt);
         } catch (IOException e) {
@@ -153,9 +153,7 @@ public class BuildMojo extends AbstractDependencyFilterMojo {
 
         HashMap<String, String> interpolations = new HashMap<String, String>();
         interpolations.put("mvn.artifactId", project.getArtifactId());
-        if( main!=null ) {
-            interpolations.put("mvn.main", main);
-        }
+        interpolations.put("mvn.main", main != null ? main : "");
 
         copyResource("bin/run", new File(binDir, "run"), "\n", interpolations);
         chmodExecutable(new File(binDir, "run"));

--- a/hawt-app-maven-plugin/src/main/resources/io/fabric8/maven/hawt/app/bin/run
+++ b/hawt-app-maven-plugin/src/main/resources/io/fabric8/maven/hawt/app/bin/run
@@ -1,53 +1,48 @@
 #!/bin/sh
-#
-# Discover the APP_HOME from the location of this script.
-#
-if [ -z "${APP_HOME}" ] ; then
-  DIRNAME=`dirname "$0"`
-  APP_HOME=`cd "$DIRNAME"/.. ; pwd`
-  export APP_HOME
+
+# ======================================
+# Startup script for flat classpath apps
+
+# Discover JAVA_APP_DIR from the script's location.
+if [ x"${JAVA_APP_DIR}" == x ] ; then
+  script_dir=`dirname "$0"`
+  JAVA_APP_DIR=`cd "$script_dir"/.. ; pwd`
+  export JAVA_APP_DIR
 fi
 
 # Setup some defaults.. can be changed via the etc/default file.
-APP_USER=""
-JVM_EXEC="java"
-JVM_ARGS="$JVM_ARGS"
-JVM_AGENT="$JVM_AGENT"
-SYSTEM_PROPERTIES="$SYSTEM_PROPERTIES"
-MAIN="${mvn.main}"
-MAIN_ARGS="$MAIN_ARGS"
-APP="${mvn.artifactId}"
+if [ x"${mvn.main}" != x ]; then
+  JAVA_MAIN_CLASS="${mvn.main}"
+elif [ x"${JAVA_MAIN_CLASS}" = x ]; then
+  echo "No JAVA_MAIN_CLASS specified"
+  exit 1
+fi
+JAVA_APP_NAME="${JAVA_APP_NAME:-${mvn.artifactId}}"
 
-IFS=$'\r\n'
-CLASSPATH=""
-for file in `cat ${APP_HOME}/lib/.classpath` ; do
-    CLASSPATH="$CLASSPATH:${APP_HOME}/lib/$file"
-done
+if [ x"${JAVA_CLASSPATH}" != x ]; then
+    classpath="${JAVA_CLASSPATH}"
+else
+    classpath="."
+    while read file; do
+        classpath="${classpath}:${JAVA_APP_DIR}/lib/$file"
+    done < ${JAVA_APP_DIR}/lib/.classpath
+fi
 
 # Source the /etc/defaults script if it exists so it can modify the
 # env vars setup so far..
-if [ -f "${APP_HOME}/etc/defaults" ] ; then
-    source ${APP_HOME}/etc/defaults
+if [ -f "${JAVA_APP_DIR}/etc/defaults" ] ; then
+    source "${JAVA_APP_DIR}/etc/defaults"
 fi
 
-JVM_DEBUG_ARGS="$JVM_DEBUG_ARGS"
-if [ -z "$JVM_DEBUG_ARGS" ]; then
-  if [ ! -z "$JVM_DEBUG" ] && [ "$JVM_DEBUG" == 'TRUE' ]; then
-    JVM_DEBUG_ARGS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005'
-  fi
+if [ x"${JAVA_ENABLE_DEBUG}" != x ]; then
+    java_debug_args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${JAVA_DEBUG_PORT:-5005}"
 fi
 
-if [ ! -z "$APP_USER" -a ! `id -un` = "$APP_USER" ] ; then
-  # re-run the launch under the right user id...
-  exec sudo -n -u ${APP_USER} $0 $@
-fi
-
-EXEC_ARGS=""
-if [ ! -z "${APP}" ] ; then
+if [ x"${JAVA_APP_NAME}" != x ] ; then
     # Not all shells support the 'exec -a newname' syntax..
     `exec -a test echo test 2> /dev/null`
     if [ "$?" -eq "1" ] ; then
-      EXEC_ARGS="-a ${APP}"
+      exec_args="-a ${JAVA_APP_NAME}"
     else
       # Lets switch to bash if you have it installed...
       if [ -f "/bin/bash" ] ; then
@@ -56,11 +51,12 @@ if [ ! -z "${APP}" ] ; then
     fi
 fi
 
-echo "Launching application in folder: $APP_HOME"
-if [ ! -z "${MAIN_ARGS}" ] ; then
-  echo "Running exec ${EXEC_ARGS} ${JVM_DEBUG_ARGS} ${JVM_AGENT} ${JVM_ARGS} ${SYSTEM_PROPERTIES} -classpath ${CLASSPATH} ${MAIN} ${MAIN_ARGS}"
-  exec ${EXEC_ARGS} ${JVM_EXEC} ${JVM_DEBUG_ARGS} ${JVM_AGENT} ${JVM_ARGS} ${SYSTEM_PROPERTIES} -classpath ${CLASSPATH} ${MAIN} ${MAIN_ARGS}
+echo "Launching application in folder: $JAVA_APP_DIR"
+arg_list="${exec_args} java ${java_debug_args} ${JAVA_OPTIONS} -classpath ${classpath} ${JAVA_MAIN_CLASS}"
+if [ x"${JAVA_MAIN_ARGS}" != x ] ; then
+    arg_list="${arg_list} ${JAVA_MAIN_ARGS}"
 else
-  echo "Running exec ${EXEC_ARGS} ${JVM_EXEC} ${JVM_DEBUG_ARGS} ${JVM_AGENT} ${JVM_ARGS} ${SYSTEM_PROPERTIES} -classpath ${CLASSPATH} ${MAIN} $@"
-  exec ${EXEC_ARGS} ${JVM_EXEC} ${JVM_DEBUG_ARGS} ${JVM_AGENT} ${JVM_ARGS} ${SYSTEM_PROPERTIES} -classpath ${CLASSPATH} ${MAIN} $@
+    arg_list="${arg_list} $@"
 fi
+echo "Running ${arg_list}"
+exec ${arg_list}


### PR DESCRIPTION
As already discussed the syntax of the run scripts should be synchronized. 

The following was adapted, including fixes:

* Checked for consistency in naming (i.e. prefix JAVA_)
* Synced with variable names from fabric8/run-java
* Consolidated environment variables influencing java options
* Introduced local var convention to be lower case
* Added missing check for JAVA_CLASSPATH env
* Fixed bug because IFS  not reset
* Introduced a JAVA_DEBUG_PORT option
* Set line ending of .classpath from \r\n to \n
* Update readme.md

Further suggestions (not implemented)

* change ".classpath" to "classpath" to make it more visible (makes it easier to find when troubleshooting)
* change etc/default to run-env.sh, colocated to the run script. Also because of maintainability: it easier to find and correlate when it is colocated.

Where I'm a bit unsure is why the separator in the .classpath file was chosen to be `\r\n` instead of plain `\n` ? (should be feasible even on windows is fits better to the target environment which is unix anyway). Or why not simply already prepare the proper classpath (colon separated) when creating ?