### PR TITLE
Resolves #4923 Upgrade Camel to version 2.16.0, Jetty9 to version 9.2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
         <!-- upstream vs redhat versions of dependencies goes here -->
         <activemq.version>5.12.0</activemq.version>
-        <camel.version>2.15.3</camel.version>
+        <camel.version>2.16.0</camel.version>
         <cxf.version>3.1.2</cxf.version>
         <!-- cxf plugin 3.1.2 has Maven NoSuchMethodError -->
         <cxf.plugin.version>3.0.6</cxf.plugin.version>
@@ -141,9 +141,9 @@
         <jasypt.version>1.9.2</jasypt.version>
         <javax.el-version>2.2.5</javax.el-version>
         <jetty-plugin-groupId>org.mortbay.jetty</jetty-plugin-groupId>
-        <jetty-plugin.version>8.1.14.v20131031</jetty-plugin.version>
-        <jetty.version>8.1.14.v20131031</jetty.version>
-        <jetty9.version>9.2.10.v20150310</jetty9.version>
+        <jetty-plugin.version>8.1.16.v20140903</jetty-plugin.version>
+        <jetty.version>8.1.17.v20150415</jetty.version>
+        <jetty9.version>9.2.11.v20150529</jetty9.version>
         <jgit.version>4.1.0.201509280440-r</jgit.version>
         <json.version>20150729</json.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
….11.v20150529, Jetty8 to version 8.1.17.v20150415 and Jetty Plugin 8.1.16.v20140903

This PR resolves #4923 

Andrea