### PR TITLE
fixes #4977 to add `mvn fabric8:rolling` as a maven goal for running rolling upgrades

### DIFF
--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/ApplyMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/ApplyMojo.java
@@ -87,6 +87,12 @@ public class ApplyMojo extends AbstractFabric8Mojo {
     private boolean createNewResources;
 
     /**
+     * Should we use rolling upgrades to apply changes?
+     */
+    @Parameter(property = "fabric8.rolling", defaultValue = "false")
+    private boolean rollingUpgrades;
+
+    /**
      * Should we fail if there is no kubernetes json
      */
     @Parameter(property = "fabric8.apply.failOnNoKubernetesJson", defaultValue = "false")
@@ -174,6 +180,7 @@ public class ApplyMojo extends AbstractFabric8Mojo {
             controller.setIgnoreRunningOAuthClients(ignoreRunningOAuthClients);
             controller.setProcessTemplatesLocally(processTemplatesLocally);
             controller.setDeletePodsOnReplicationControllerUpdate(deletePodsOnReplicationControllerUpdate);
+            controller.setRollingUpgrade(rollingUpgrades);
 
             boolean openShift = KubernetesHelper.isOpenShift(kubernetes);
             getLog().info("Is OpenShift: " + openShift);
@@ -238,6 +245,14 @@ public class ApplyMojo extends AbstractFabric8Mojo {
         } catch (Exception e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
+    }
+
+    public boolean isRollingUpgrades() {
+        return rollingUpgrades;
+    }
+
+    public void setRollingUpgrades(boolean rollingUpgrades) {
+        this.rollingUpgrades = rollingUpgrades;
     }
 
     /**

--- a/fabric8-maven-plugin/src/main/java/io/fabric8/maven/RollingMojo.java
+++ b/fabric8-maven-plugin/src/main/java/io/fabric8/maven/RollingMojo.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Like the <code>apply</code> goal but forces a rolling upgrade of all the Replication Controllers
+ */
+@Mojo(name = "rolling", requiresDependencyResolution = ResolutionScope.RUNTIME, defaultPhase = LifecyclePhase.INSTALL)
+public class RollingMojo extends ApplyMojo {
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        setRollingUpgrades(true);
+        super.execute();
+
+    }
+}


### PR DESCRIPTION
fixes #4977 to add `mvn fabric8:rolling` as a maven goal for running rolling upgrades