### PR TITLE
Fix JadvisorKubernetesTest link in Fabric8-arquillian README.md file

### DIFF
--- a/components/fabric8-arquillian/ReadMe.md
+++ b/components/fabric8-arquillian/ReadMe.md
@@ -6,7 +6,7 @@ This library provides an [Arquillian](http://arquillian.org/) plugin for [integr
 
 There are lots of examples in the [quickstarts](http://fabric8.io/guide/quickstarts.html).
 
-Here is an [example Arquillian Fabric8 integration test](https://github.com/fabric8io/quickstarts/blob/master/apps/jadvisor/src/test/java/io/fabric8/apps/jadvisor/JadvisorKubernetesTest.java#L42)
+Here is an [example Arquillian Fabric8 integration test](https://github.com/fabric8io/ipaas-quickstarts/blob/master/sandbox/apps/jadvisor/src/test/java/io/fabric8/apps/jadvisor/JadvisorKubernetesTest.java#L41)
 
 ### Assertion libraries
 


### PR DESCRIPTION
Just a broken link fix in Fabric8-arquillian README.md file.

Andrea