### PR TITLE
#5119 fix combineJson when not Template object exists

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
@@ -1113,9 +1113,11 @@ public final class KubernetesHelper {
                 addObjectsToItemArray(items, object);
             }
         }
+        KubernetesList fullList = new KubernetesList();
+        fullList.setItems(items);
         moveServicesToFrontOfArray(items);
         removeDuplicates(items);
-        Object answer = Templates.combineTemplates(list, items);
+        Object answer = Templates.combineTemplates(fullList);
         items = toItemList(answer);
         removeDuplicates(items);
         return answer;


### PR DESCRIPTION
fixes _fabric8.extra.json_ used to combine kubernetes-extra.json when there are no Template objects