### PR TITLE
allow git diffs to use the same object id for the diff to see exactly one commits change

### DIFF
--- a/forge/fabric8-forge-core/src/main/java/io/fabric8/forge/rest/git/RepositoryResource.java
+++ b/forge/fabric8-forge-core/src/main/java/io/fabric8/forge/rest/git/RepositoryResource.java
@@ -252,7 +252,7 @@ public class RepositoryResource {
             commit = CommitUtils.getHead(r);
         }
         RevCommit baseCommit = null;
-        if (Strings.isNotBlank(baseObjectId)) {
+        if (Strings.isNotBlank(baseObjectId) && !Objects.equals(baseObjectId, objectId)) {
             baseCommit = CommitUtils.getCommit(r, baseObjectId);
         }
 


### PR DESCRIPTION
allow git diffs to use the same object id for the diff to see exactly one commits change