### PR TITLE
adjust boolean logic to correctly log the waiting of containers.

### DIFF
--- a/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/kubernetes/await/SessionPodsAreReady.java
+++ b/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/kubernetes/await/SessionPodsAreReady.java
@@ -50,8 +50,8 @@ public class SessionPodsAreReady implements Callable<Boolean> {
         }
 
         for (Pod pod : pods) {
-            result = result && KubernetesHelper.isPodReady(pod);
-            if (!result) {
+            if (!KubernetesHelper.isPodReady(pod)) {
+                result = false;
                 PodStatus podStatus = pod.getStatus();
                 if (podStatus != null) {
                     List<ContainerStatus> containerStatuses = podStatus.getContainerStatuses();


### PR DESCRIPTION
sorry guys. i realized my pull request from earlier was using slightly flawed boolean logic for determining the log messages to output while waiting for containers to be ready. this addresses that issue. thanks!