### PR TITLE
Upgrade Jgit to version 4.2.0.201601211800-r

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
 <!--
         We've released a new version of gitective with the latest jgit support
 -->
-        <jgit.version>4.1.1.201511131810-r</jgit.version>
+        <jgit.version>4.2.0.201601211800-r</jgit.version>
         <json.version>20151123</json.version>
         <junit.version>4.12</junit.version>
         <kubernetes-client.version>1.3.66</kubernetes-client.version>


### PR DESCRIPTION
Upgrade to latest Jgit. Hawtio is using the latest version of gitective on Master, this way the jgit we are using on fabric8 and hawtio will be the same.

Andrea