### PR TITLE
lets use the LoadBalancer status IP if no ingress/routes and no portalIP on GKE

### DIFF
--- a/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
+++ b/components/kubernetes-api/src/main/java/io/fabric8/kubernetes/api/KubernetesHelper.java
@@ -1357,6 +1357,27 @@ public final class KubernetesHelper {
                     }
                 }
             }
+
+            // lets try use the status on GKE
+            ServiceStatus status = srv.getStatus();
+            if (status != null) {
+                LoadBalancerStatus loadBalancerStatus = status.getLoadBalancer();
+                if (loadBalancerStatus != null) {
+                    List<LoadBalancerIngress> loadBalancerIngresses = loadBalancerStatus.getIngress();
+                    if (loadBalancerIngresses != null) {
+                        for (LoadBalancerIngress loadBalancerIngress : loadBalancerIngresses) {
+                            String ip = loadBalancerIngress.getIp();
+                            if (Strings.isNotBlank(ip)) {
+                                portalIP = ip;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (Strings.isNullOrBlank(portalIP)) {
             // on vanilla kubernetes we can use nodePort to access things externally
             Integer nodePort = port.getNodePort();
             if (nodePort != null) {


### PR DESCRIPTION
lets use the LoadBalancer status IP if no ingress/routes and no portalIP on GKE