### PR TITLE
Use valid k8s port name

### DIFF
--- a/components/fabric8-jgroups/src/main/java/io/fabric8/jgroups/Constants.java
+++ b/components/fabric8-jgroups/src/main/java/io/fabric8/jgroups/Constants.java
@@ -20,5 +20,5 @@ public class Constants {
     public static final short KUBERNETES_DISCOVERY_ID = 1001;
     
     public static final String JGROUPS_CLUSTER_NAME = "cluster";
-    public static final String JGROUPS_TCP_PORT = "jgroups-tcp-port";
+    public static final String JGROUPS_TCP_PORT = "jgroups-tcp";
 }


### PR DESCRIPTION
Hi!

"jgroups-tcp-port" is not a valid name for a port in Kubernetes: http://kubernetes.io/docs/api-reference/v1/definitions/#_v1_containerport