### PR TITLE
Split fabric8-karaf package to provide single functionalities

### DIFF
--- a/components/fabric8-karaf/fabric8-karaf-blueprint/pom.xml
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.fabric8</groupId>
+        <version>2.2-SNAPSHOT</version>
+        <artifactId>fabric8-karaf</artifactId>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>fabric8-karaf-blueprint</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Fabric8 :: Karaf :: Blueprint</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.aries.blueprint</groupId>
+            <artifactId>org.apache.aries.blueprint.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <defaultGoal>install</defaultGoal>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <excludeDependencies>${fuse.osgi.exclude.dependencies}</excludeDependencies>
+                    <instructions>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>io.fabric8.karaf.blueprint;version=${project.version};-noimport:=true</Export-Package>
+                        <Import-Package>*</Import-Package>
+                        <Private-Package></Private-Package>
+                        <Implementation-Title>Fabric8 Karaf Blueprint Support</Implementation-Title>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Include-Resource>{maven-resources}</Include-Resource>
+                        <_failok>false</_failok>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/CamelPropertyEvaluator.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/CamelPropertyEvaluator.java
@@ -14,7 +14,7 @@
  * permissions and limitations under the License.
  */
 
-package io.fabric8.karaf;
+package io.fabric8.karaf.blueprint;
 
 import java.util.Dictionary;
 import java.util.LinkedHashMap;

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/EnvPropertiesFunction.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/EnvPropertiesFunction.java
@@ -14,10 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.karaf;
-
-import static io.fabric8.karaf.Support.after;
-import static io.fabric8.karaf.Support.before;
+package io.fabric8.karaf.blueprint;
 
 /**
  * A {@link org.apache.camel.component.properties.PropertiesFunction} that lookup the property value from
@@ -36,8 +33,8 @@ public class EnvPropertiesFunction implements PropertiesFunction {
         String defaultValue = null;
 
         if (remainder.contains(":")) {
-            key = before(remainder, ":");
-            defaultValue = after(remainder, ":");
+            key = Support.before(remainder, ":");
+            defaultValue = Support.after(remainder, ":");
         }
 
         String value = System.getenv(key);

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/KubernetesPropertyEvaluator.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/KubernetesPropertyEvaluator.java
@@ -13,7 +13,7 @@
  *  implied.  See the License for the specific language governing
  *  permissions and limitations under the License.
  */
-package io.fabric8.karaf;
+package io.fabric8.karaf.blueprint;
 
 import java.util.Dictionary;
 import java.util.Map;

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/PropertiesFunction.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/PropertiesFunction.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.karaf;
+package io.fabric8.karaf.blueprint;
 
 /**
  * A function that is applied instead of looking up a property placeholder.

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/ServiceHostPropertiesFunction.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/ServiceHostPropertiesFunction.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.karaf;
+package io.fabric8.karaf.blueprint;
 
 import java.util.Locale;
-
-import static io.fabric8.karaf.Support.after;
-import static io.fabric8.karaf.Support.before;
 
 /**
  * A {@link PropertiesFunction} that lookup the property value from
@@ -52,8 +49,8 @@ public class ServiceHostPropertiesFunction implements PropertiesFunction {
         String defaultValue = null;
 
         if (remainder.contains(":")) {
-            key = before(remainder, ":");
-            defaultValue = after(remainder, ":");
+            key = Support.before(remainder, ":");
+            defaultValue = Support.after(remainder, ":");
         }
 
         // make sure to use upper case

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/ServicePortPropertiesFunction.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/ServicePortPropertiesFunction.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.karaf;
+package io.fabric8.karaf.blueprint;
 
 import java.util.Locale;
-
-import static io.fabric8.karaf.Support.after;
-import static io.fabric8.karaf.Support.before;
 
 /**
  * A {@link org.apache.camel.component.properties.PropertiesFunction} that lookup the property value from
@@ -52,8 +49,8 @@ public class ServicePortPropertiesFunction implements PropertiesFunction {
         String defaultValue = null;
 
         if (remainder.contains(":")) {
-            key = before(remainder, ":");
-            defaultValue = after(remainder, ":");
+            key = Support.before(remainder, ":");
+            defaultValue = Support.after(remainder, ":");
         }
 
         // make sure to use upper case

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/ServicePropertiesFunction.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/ServicePropertiesFunction.java
@@ -14,12 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.karaf;
+package io.fabric8.karaf.blueprint;
 
 import java.util.Locale;
-
-import static io.fabric8.karaf.Support.after;
-import static io.fabric8.karaf.Support.before;
 
 /**
  * A {@link org.apache.camel.component.properties.PropertiesFunction} that lookup the property value from
@@ -48,8 +45,8 @@ public class ServicePropertiesFunction implements PropertiesFunction {
         String defaultValue = null;
 
         if (remainder.contains(":")) {
-            key = before(remainder, ":");
-            defaultValue = after(remainder, ":");
+            key = Support.before(remainder, ":");
+            defaultValue = Support.after(remainder, ":");
         }
 
         // make sure to use upper case

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/Support.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/Support.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package io.fabric8.karaf;
+package io.fabric8.karaf.blueprint;
 
 public class Support {
 

--- a/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/SysPropertiesFunction.java
+++ b/components/fabric8-karaf/fabric8-karaf-blueprint/src/main/java/io/fabric8/karaf/blueprint/SysPropertiesFunction.java
@@ -14,10 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.karaf;
-
-import static io.fabric8.karaf.Support.after;
-import static io.fabric8.karaf.Support.before;
+package io.fabric8.karaf.blueprint;
 
 /**
  * A {@link PropertiesFunction} that lookup the property value from
@@ -36,8 +33,8 @@ public class SysPropertiesFunction implements PropertiesFunction {
         String defaultValue = null;
 
         if (remainder.contains(":")) {
-            key = before(remainder, ":");
-            defaultValue = after(remainder, ":");
+            key = Support.before(remainder, ":");
+            defaultValue = Support.after(remainder, ":");
         }
 
         String value = System.getProperty(key);

--- a/components/fabric8-karaf/fabric8-karaf-cm/pom.xml
+++ b/components/fabric8-karaf/fabric8-karaf-cm/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.fabric8</groupId>
+        <version>2.2-SNAPSHOT</version>
+        <artifactId>fabric8-karaf</artifactId>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>fabric8-karaf-cm</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Fabric8 :: Karaf :: CM</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <defaultGoal>install</defaultGoal>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <excludeDependencies>${fuse.osgi.exclude.dependencies}</excludeDependencies>
+                    <instructions>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>io.fabric8.karaf.cm;version=${project.version};-noimport:=true</Export-Package>
+                        <Import-Package>
+                            org.apache.felix.cm;version="[1,2)",
+                            *
+                        </Import-Package>
+                        <Private-Package></Private-Package>
+                        <Implementation-Title>Fabric8 Karaf ConfigAdmin Support</Implementation-Title>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Include-Resource>{maven-resources}</Include-Resource>
+                        <_failok>false</_failok>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/components/fabric8-karaf/fabric8-karaf-cm/src/main/java/io/fabric8/karaf/cm/KubernetesPersistenceManager.java
+++ b/components/fabric8-karaf/fabric8-karaf-cm/src/main/java/io/fabric8/karaf/cm/KubernetesPersistenceManager.java
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2005-2016 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
  *  Copyright 2005-2016 Red Hat, Inc.
  *
  *  Red Hat licenses this file to you under the Apache License, version
@@ -13,7 +29,7 @@
  *  implied.  See the License for the specific language governing
  *  permissions and limitations under the License.
  */
-package io.fabric8.karaf;
+package io.fabric8.karaf.cm;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/components/fabric8-karaf/fabric8-karaf-features/pom.xml
+++ b/components/fabric8-karaf/fabric8-karaf-features/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2005-2016 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version
+  ~ 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.  See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.fabric8</groupId>
+    <version>2.2-SNAPSHOT</version>
+    <artifactId>fabric8-karaf</artifactId>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>fabric8-karaf-features</artifactId>
+
+  <name>Fabric8 :: Karaf :: Features</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.10</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>attach-artifacts</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>target/feature.xml</file>
+                  <type>xml</type>
+                  <classifier>features</classifier>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.6</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.basedir}/target</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+
+</project>

--- a/components/fabric8-karaf/fabric8-karaf-features/src/main/resources/feature.xml
+++ b/components/fabric8-karaf/fabric8-karaf-features/src/main/resources/feature.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright 2005-2016 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version
+  ~ 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.  See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0" name="fabric8-karaf-features-${project.version}">
+
+  <feature name="fabric8-karaf-blueprint" description="Fabric8 Karaf Blueprint" version="${project.version}">
+    <bundle dependency="true">mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
+    <bundle start-level="60">mvn:io.fabric8/fabric8-karaf-blueprint/${project.version}</bundle>
+  </feature>
+
+  <feature name="fabric8-karaf-cm" description="Fabric8 Karaf ConfigAdmin" version="${project.version}">
+    <bundle start-level="60">mvn:io.fabric8/fabric8-karaf-cm/${project.version}</bundle>
+  </feature>
+
+</features>

--- a/components/fabric8-karaf/pom.xml
+++ b/components/fabric8-karaf/pom.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+  ~ Copyright 2005-2016 Red Hat, Inc.
+  ~
+  ~ Red Hat licenses this file to you under the Apache License, version
+  ~ 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  ~ implied.  See the License for the specific language governing
+  ~ permissions and limitations under the License.
+  -->
+
+<!--
 
      Copyright 2005-2016 Red Hat, Inc.
 
@@ -16,112 +32,23 @@
      permissions and limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>io.fabric8</groupId>
-        <version>2.2-SNAPSHOT</version>
-        <artifactId>components</artifactId>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.fabric8</groupId>
+    <artifactId>components</artifactId>
+    <version>2.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>fabric8-karaf</artifactId>
-    <packaging>bundle</packaging>
+  <artifactId>fabric8-karaf</artifactId>
+  <packaging>pom</packaging>
 
-    <name>Fabric8 :: Karaf</name>
+  <name>Fabric8 :: Components :: Karaf</name>
 
-    <dependencies>
-
-        <dependency>
-            <groupId>org.apache.aries.blueprint</groupId>
-            <artifactId>org.apache.aries.blueprint.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.configadmin</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-    </dependencies>
-
-
-    <build>
-        <defaultGoal>install</defaultGoal>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
-
-        <plugins>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <excludeDependencies>${fuse.osgi.exclude.dependencies}</excludeDependencies>
-                    <instructions>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Export-Package>io.fabric8.karaf;version=${project.version};-noimport:=true</Export-Package>
-                        <Import-Package>*</Import-Package>
-                        <Private-Package></Private-Package>
-                        <Implementation-Title>Fabric8 Karaf Support</Implementation-Title>
-                        <Implementation-Version>${project.version}</Implementation-Version>
-                        <Include-Resource>{maven-resources}</Include-Resource>
-                        <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
-                        <_failok>false</_failok>
-                    </instructions>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
-
+  <modules>
+    <!-- karaf support -->
+    <module>fabric8-karaf-blueprint</module>
+    <module>fabric8-karaf-cm</module>
+    <module>fabric8-karaf-features</module>
+  </modules>
 </project>


### PR DESCRIPTION
@jimmidyson 

This PR is aimed to split fabric8-karaf in sub packages so one can install the required functionalities only and can easily adapt do different karaf runtime (i.e. static)

Let me know it it looks good.
