### PR TITLE
OSFUSE-47 - Fixing up  fabric8-karaf-checks feature

### DIFF
--- a/components/fabric8-karaf/fabric8-karaf-checks/pom.xml
+++ b/components/fabric8-karaf/fabric8-karaf-checks/pom.xml
@@ -45,8 +45,8 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
+            <version>3.0.1</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/components/fabric8-karaf/fabric8-karaf-features/src/main/resources/feature.xml
+++ b/components/fabric8-karaf/fabric8-karaf-features/src/main/resources/feature.xml
@@ -17,6 +17,7 @@
 
   <feature name="fabric8-karaf-checks" description="Fabric8 Karaf Checks" version="${project.version}">
     <feature>scr</feature>
+    <feature>http</feature>
     <bundle start-level="60">mvn:io.fabric8/fabric8-karaf-checks/${project.version}</bundle>
   </feature>
 


### PR DESCRIPTION
It depends on the http feature, and the adjust the dependency in on the servlet api to avoid conflicts.