### PR TITLE
Aligning spring-boot dependencies after release of Camel 2.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <shrinkwrap-resolver.version>2.2.2</shrinkwrap-resolver.version>
         <slf4j.version>1.7.12</slf4j.version>
         <spring.version>4.2.7.RELEASE</spring.version>
-        <spring.boot.version>1.3.7.RELEASE</spring.boot.version>
+        <spring.boot.version>1.4.1.RELEASE</spring.boot.version>
         <sundrio.version>0.3.9</sundrio.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <zookeeper.version>3.4.8</zookeeper.version>
@@ -205,9 +205,6 @@
         <fuse.osgi.capabilities.provide />
         <fuse.osgi.capabilities.require />
 
-        <!-- Properties related to the per-stack BOMS -->
-        <camel-spring-boot-bom.camel.version>2.17.3</camel-spring-boot-bom.camel.version>
-        <camel-spring-boot-bom.spring-boot.version>1.3.7.RELEASE</camel-spring-boot-bom.spring-boot.version>
     </properties>
 
     <distributionManagement>
@@ -1420,15 +1417,18 @@
                                   <include>org.jboss.arquillian*:*</include>
                                   <include>org.jboss.shrinkwrap*:*</include>
 
-                                  <include>org.codehaus.plexus:plexus-utils</include>
                                   <include>xml-apis:xml-apis</include>
                               </includes>
+                              <excludes>
+                                  <exclude>javax.servlet:javax.servlet-api</exclude>
+                                  <exclude>javax.activation:activation:1.1</exclude>
+                              </excludes>
                           </dependencies>
                           <imports>
                               <import>
                                   <groupId>org.springframework.boot</groupId>
                                   <artifactId>spring-boot-dependencies</artifactId>
-                                  <version>${camel-spring-boot-bom.spring-boot.version}</version>
+                                  <version>${spring.boot.version}</version>
                                   <dependencyManagement>
                                       <includes>
                                           <include>*:*</include>
@@ -1437,25 +1437,12 @@
                               </import>
                               <import>
                                   <groupId>org.apache.camel</groupId>
-                                  <artifactId>camel-parent</artifactId>
-                                  <version>${camel-spring-boot-bom.camel.version}</version>
+                                  <artifactId>camel-spring-boot-dependencies</artifactId>
+                                  <version>${camel.version}</version>
                                   <dependencyManagement>
                                       <includes>
                                           <include>*:*</include>
                                       </includes>
-                                      <excludes>
-                                          <exclude>com.fasterxml.jackson*:*</exclude>
-                                          <exclude>de.flapdoodle*:*</exclude>
-                                          <exclude>junit*:*</exclude>
-                                          <exclude>org.apache.activemq*:*</exclude>
-                                          <exclude>org.apache.derby*:*</exclude>
-                                          <exclude>org.apache.httpcomponents*:*</exclude>
-                                          <exclude>org.codehaus.groovy*:*</exclude>
-                                          <exclude>org.hibernate:hibernate-entitymanager</exclude>
-                                          <exclude>org.mockito*:*</exclude>
-                                          <exclude>org.springframework*:*</exclude>
-                                          <exclude>net.sf.ehcache*:*</exclude>
-                                      </excludes>
                                   </dependencyManagement>
                               </import>
                           </imports>


### PR DESCRIPTION
This upgrades spring-boot to 1.4.1.RELEASE (aligned with Camel 2.18.0) and updates the stack BOM with the correct dependencies.