### PR TITLE
OSFUSE-341: Use a consistent version of cdi-api when modules are disa…

### DIFF
--- a/components/fabric8-cdi/pom.xml
+++ b/components/fabric8-cdi/pom.xml
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
-            <version>1.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <httpclient.version>4.5.2</httpclient.version>
         <jackson2.version>2.7.4</jackson2.version>
         <jar.plugin.version>2.6</jar.plugin.version>
+        <javax.cdi-api.version>1.2</javax.cdi-api.version>
         <javax.el-version>2.2.5</javax.el-version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jetty-plugin-groupId>org.mortbay.jetty</jetty-plugin-groupId>
@@ -1292,7 +1293,11 @@
               <artifactId>hibernate-validator</artifactId>
               <version>${hibernate-validator.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>javax.enterprise</groupId>
+                <artifactId>cdi-api</artifactId>
+                <version>${javax.cdi-api.version}</version>
+            </dependency>
             <dependency>
               <groupId>javax.el</groupId>
               <artifactId>javax.el-api</artifactId>


### PR DESCRIPTION
…bled

Happens that CDI 1.0 is taken transitively when some modules are excluded from the build.