### PR TITLE
OSFUSE-168: Remove the fabric8-project-bom-full

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1543,25 +1543,6 @@
                           <inheritDependencyManagement>true</inheritDependencyManagement>
                           <inheritPluginManagement>true</inheritPluginManagement>
                       </bom>
-                      <bom>
-                          <artifactId>fabric8-project-bom-full</artifactId>
-                          <name>Fabric8 :: Project :: Bom with Eveything</name>
-                          <dependencies>
-                              <includes>
-                                  <include>*:*</include>
-                              </includes>
-                          </dependencies>
-                          <plugins>
-                              <includes>
-                                  <include>io.fabric8:*</include>
-                              </includes>
-                          </plugins>
-                          <properties>
-                              <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                          </properties>
-                          <inheritDependencyManagement>true</inheritDependencyManagement>
-                          <inheritPluginManagement>true</inheritPluginManagement>
-                      </bom>
                   </boms>
               </configuration>
               <executions>


### PR DESCRIPTION
The fabric8-project-bom-full can be removed (https://issues.jboss.org/browse/OSFUSE-168).

There are 2 linked PRs to remove references to it in other fabric8 projects (should be merged before):
- https://github.com/fabric8io/funktion/pull/119
- https://github.com/fabric8io/portswizzler/pull/9