### PR TITLE
OSFUSE-325: Use the Bearer token authentication on Openshift

### DIFF
--- a/components/kubernetes-jolokia/src/main/java/io/fabric8/kubernetes/jolokia/BearerTokenAuthenticator.java
+++ b/components/kubernetes-jolokia/src/main/java/io/fabric8/kubernetes/jolokia/BearerTokenAuthenticator.java
@@ -1,0 +1,58 @@
+/**
+ *  Copyright 2005-2016 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package io.fabric8.kubernetes.jolokia;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+import org.jolokia.client.J4pAuthenticator;
+
+import java.io.IOException;
+
+/**
+ * Authenticator using the Bearer token.
+ *
+ * The token is expected to be provided in the pUser field of the {@link BearerTokenAuthenticator#authenticate(HttpClientBuilder, String, String)} method.
+ */
+public class BearerTokenAuthenticator implements J4pAuthenticator {
+
+    public BearerTokenAuthenticator() {
+    }
+
+    /** {@inheritDoc} */
+    public void authenticate(HttpClientBuilder pBuilder, String pUser, String pPassword) {
+        pBuilder.addInterceptorFirst(new PreemptiveBearerInterceptor(pUser));
+    }
+
+
+    // =================================================================================================
+
+    static class PreemptiveBearerInterceptor implements HttpRequestInterceptor {
+
+        private String token;
+
+        public PreemptiveBearerInterceptor(String token) {
+            this.token = token;
+        }
+
+        /** {@inheritDoc} */
+        public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
+            request.addHeader("Authorization", "Bearer " + token);
+        }
+    }
+}


### PR DESCRIPTION
This should fix the usage of Jolokia clients in Kubernetes-Arquillian. 

The way I fixed it is providing a mechanism to configure the protocol used by Jolokia (http/https) and the authentication mode (BASIC vs BEARER token).

I also configured the following defaults:
- Openshift: https with BEARER token authentication
- Kubernetes: http with BASIC authentication (non-preemptive, so optional)

Now the Jolokia client uses the SSL context of the Kubernetes client in proxy mode, so no more problems with client/server certificates.

I tested (successfully) everything on **Minishift and Minikube** (using a spring-boot quickstart).

A snippet of the test:
```java
@RunWith(Arquillian.class)
public class KubernetesIntegrationKT {

    @ArquillianResource
    KubernetesClient client;

    @ArquillianResource
    Session session;

    @ArquillianResource
    JolokiaClients jolokiaClients;

    @Test
    @RunAsClient
    public void testAppProvisionsRunningPods() throws Exception {
        assertThat(client).deployments().pods().isPodReadyForPeriod();

        Pod pod = client.pods().list().getItems().get(0);

        J4pClient jolokiaClient = jolokiaClients.clientForPod(pod);

        assertThat(jolokiaClient).doubleAttribute("java.lang:type=OperatingSystem", "SystemCpuLoad").isGreaterThanOrEqualTo(0.0);

    }
}
```