### PR TITLE
Revert "Upgrade Hibernate-validator to version 5.3.1.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
         <commons.collections.version>3.2.2</commons.collections.version>
         <fuse.version>6.3.0.redhat-187</fuse.version>
-        <hibernate-validator.version>5.3.1.Final</hibernate-validator.version>
+        <hibernate-validator.version>5.3.0.Final</hibernate-validator.version>
         <jansi.version>1.11</jansi.version>
         <jolokia.version>1.3.5</jolokia.version>
         <jgroups.version>3.6.11.Final</jgroups.version>


### PR DESCRIPTION
We are seeing issues with fabric8-forge pull requests after upgrading fabric8 see https://github.com/fabric8io/fabric8-forge/pull/675

This reverts commit 0dc6658ae3cffc807793341084099a1148db8370.