### PR TITLE
Revert "Revert "Upgrade Hibernate-validator to version 5.3.1.Final""

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
         <commons.collections.version>3.2.2</commons.collections.version>
         <fuse.version>6.3.0.redhat-187</fuse.version>
-        <hibernate-validator.version>5.3.0.Final</hibernate-validator.version>
+        <hibernate-validator.version>5.3.1.Final</hibernate-validator.version>
         <jansi.version>1.11</jansi.version>
         <jolokia.version>1.3.5</jolokia.version>
         <jgroups.version>3.6.11.Final</jgroups.version>


### PR DESCRIPTION
Add the hibernate validater upgrade back in now we have updated fabric8-forge to work with it https://github.com/fabric8io/fabric8-forge/commit/f23d6790b59defea4afa7d53ad936b18eae5caeb

This reverts commit c2d64804658a46e5c81b9e575afa7cc2be64b16e.