### PR TITLE
OSFUSE-410: remove the WARN in logs

### DIFF
--- a/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/utils/Namespaces.java
+++ b/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/utils/Namespaces.java
@@ -80,7 +80,9 @@ public class Namespaces {
                     .endMetadata()
                     .done();
         } catch (Exception e) {
-            LOG.warn("failed to update namespace: " + e, e);
+            // A user working on an existing namespace might not have access to
+            // update the metadata on the namespace.  So don't be verbose with this error.
+            LOG.debug("failed to update namespace: " + e, e);
             return null;
         }
     }


### PR DESCRIPTION
If a user is not admin, he could get WARNs when using arq tests.