### PR TITLE
homepage terminology changes with Dev Leads team to match tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>fabric8: open source Integrated Developer Platform for Continuous Delivery of Microservices</title>
+    <title>fabric8: open source Integrated Development Platform for Kubernetes</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     <meta content="an open source developer platform" name="description" />
     <link href="/stylesheets/normalize.css" rel="stylesheet">
@@ -46,7 +46,7 @@
             </a>
           </div>
           <div class="col-lg-6 text-center visible-lg">
-            <h1>integrated developer platform</h1>
+            <h1>integrated development platform</h1>
           </div>
         </div>
       </div>
@@ -110,17 +110,17 @@
   <div class="container">
   <div class="row">
     <div class="col-md-12">
-      <h1>Integrated Developer Platform for Kubernetes</h1>
+      <h1>Integrated Development Platform for Kubernetes</h1>
     </div>
   </div>
 
   <div class="row">
     <div class="col-md-12">
-      <p class="text-center intro-para">
-        <b>fabric8</b> is an opinionated and open source <b>Integrated Developer Platform</b> for the <a
+      <!-- <p class="text-center intro-para">
+        <b>fabric8</b> is an opinionated and open source <b>Integrated Development Platform</b> for the <a
               href="http://fabric8.io/guide/cdelivery.html">Continuous Delivery</a> of Microservices using <a
               href="http://kubernetes.io/">Kubernetes</a> and <a href="https://jenkins.io/">Jenkins</a>
-      </p>
+      </p> -->
     </div>
   </div>
 
@@ -161,7 +161,8 @@
               href="http://fabric8.io/guide/getStarted/gofabric8.html">OpenShift</a> cluster or the <a href="https://stackpoint.io/#/clusters/new?provider=aws&amp;solution=fabric8">public cloud</a>
       </p>
       <p class="text-center last-para">
-        <b>fabric8</b> makes it easy to create microservices, build, test and deploy them via <a
+        <b>fabric8</b> is an end to end development platform spanning ideation to production for the creation of cloud native applications and microservices.
+         You can build, test and deploy your applications via <a
               href="http://fabric8.io/guide/cdelivery.html">Continuous Delivery pipelines</a> then <a
               href="http://fabric8.io/guide/fabric8DevOps.html">run and manage them</a> with Continuous Improvement and
         <a href="http://fabric8.io/guide/chat.html">ChatOps</a>
@@ -330,7 +331,7 @@
   </div>
   <div class="row">
     <div class="col-md-12">
-      <h1>Additional Microservices</h1>
+      <h1>Integrations</h1>
     </div>
   </div>
 
@@ -529,18 +530,6 @@
             A PaaS (Platform As A Service) based on Docker and Kubernetes
           </td>
           <td class="icon-column">
-            <a href="https://github.com/fabric8io/kansible">
-              <img class="logo" src="../images/logos/kansible.png"/>
-              Kansible
-            </a>
-          </td>
-          <td class="icon-desc-column">
-            orchestrate operating system processes on Windows or Unix like
-            Docker containers using <a href="https://www.ansible.com/">Ansible</a>
-          </td>
-        </tr>
-        <tr>
-          <td class="icon-column">
             <a href="http://manageiq.org/">
               <img class="logo" src="../images/logos/manageiq.png"/>
               ManageIQ
@@ -549,7 +538,6 @@
           <td class="icon-desc-column">
             Cloud Management
           </td>
-          <td colspan="2">&nbsp;</td>
         </tr>
       </table>
 
@@ -617,7 +605,7 @@
       </table>
 
 
-      <h4>Transparency</h4>
+      <h4>Collaboration</h4>
 
       <table class="table services">
         <tr>


### PR DESCRIPTION
- Updated tagline across index page to be "Integrated Development Platform", and updated paragraph descriptions given input from dev tooling lead team
- Renamed "Additional Microservices" to "Integrations"
- removed kansible from integrations list

Changes were made due to discussions in a meeting with development team leads, and can be followed up with Carl Trieloff.