### PR TITLE
OSFUSE-447: generating BOM using RH conventions

### DIFF
--- a/custom-bom.xml.vm
+++ b/custom-bom.xml.vm
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>${model.groupId}</groupId>
+    <artifactId>${model.artifactId}</artifactId>
+    <version>${model.version}</version>
+    <name>${model.name}</name>
+    <packaging>pom</packaging>
+    <description>Bill of material</description>
+    #if ($model.url)
+
+        <url>${model.url}</url>#end
+    #if ($model.licenses && !$model.licenses.isEmpty())
+
+        <licenses>#foreach($l in $model.licenses)
+
+            <license>
+                <name>${l.name}</name>
+                <url>${l.url}</url>
+                <distribution>${l.distribution}</distribution>
+            </license>#end
+
+        </licenses>
+    #end
+
+    #if ($model.scm)
+
+        <scm>
+            <connection>${model.scm.connection}</connection>
+            <developerConnection>${model.scm.developerConnection}</developerConnection>
+            <url>${model.scm.connection}</url>
+            <tag>${model.scm.tag}</tag>
+        </scm>
+    #end
+
+    #if ($model.developers && !$model.developers.isEmpty())
+        <developers>#foreach($d in $model.developers)
+
+            <developer>
+                <id>${d.id}</id>
+                <name>${d.name}</name>#if($d.email)
+
+                <email>${d.email}</email>#end#if($d.url)
+
+                <url>${d.url}</url>#end#if($d.organization)
+
+                <organization>${d.organization}</organization>#end#if($d.organizationUrl)
+
+                <organizationUrl>${d.organizationUrl}</organizationUrl>#end
+
+            </developer>#end
+
+        </developers>#end
+
+
+    <properties>#foreach($d in $model.dependencyManagement.dependencies)
+
+        <version.${d.groupId}.${d.artifactId}>${d.version}</version.${d.groupId}.${d.artifactId}>#end#foreach($p in $model.build.pluginManagement.plugins)
+
+        <version.${p.groupId}.${p.artifactId}>${p.version}</version.${p.groupId}.${p.artifactId}>#end
+
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>#foreach($d in $model.dependencyManagement.dependencies)
+
+            <dependency>
+                <groupId>${d.groupId}</groupId>
+                <artifactId>${d.artifactId}</artifactId>
+                <version>#[[$]]#{version.${d.groupId}.${d.artifactId}}</version>#if( $d.scope && $!d.scope != '' )
+
+                <scope>${d.scope}</scope>#end#if( $d.type && $!d.type != '' && $!d.type != 'jar' && $!d.type != 'bundle')
+
+                <type>${d.type}</type>#end#if( $d.classifier && $!d.classifier != '' )
+
+                <classifier>${d.classifier}</classifier>#end#if( $d.exclusions && $d.exclusions.size() > 0 )
+
+                <exclusions>#foreach( $e in $d.exclusions )
+
+                    <exclusion>
+                        <groupId>${e.groupId}</groupId>
+                        <artifactId>${e.artifactId}</artifactId>
+                    </exclusion>#end
+
+                </exclusions>#end
+
+            </dependency>#end
+
+        </dependencies>
+    </dependencyManagement>
+    #if (!$model.build.pluginManagement.plugins.isEmpty())
+
+        <build>
+            <pluginManagement>
+                <plugins>#foreach($p in $model.build.pluginManagement.plugins)
+
+                    <plugin>
+                        <groupId>${p.groupId}</groupId>
+                        <artifactId>${p.artifactId}</artifactId>
+                        <version>#[[$]]#{version.${p.groupId}.${p.artifactId}}</version>
+                    </plugin>#end
+
+                </plugins>
+            </pluginManagement>
+        </build>
+    #end
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1374,6 +1374,7 @@
               <artifactId>sundr-maven-plugin</artifactId>
               <version>${sundrio.version}</version>
               <configuration>
+                  <bomTemplateUrl>file://${project.basedir}/custom-bom.xml.vm</bomTemplateUrl>
                   <boms>
                       <bom>
                           <artifactId>fabric8-project-bom</artifactId>

--- a/readme.md
+++ b/readme.md
@@ -51,4 +51,3 @@ Check out the [Community](http://fabric8.io/community/index.html)
 ### License
 
 This project is [Apache Licensed](license.txt)
-


### PR DESCRIPTION
The BOM must contain a property which defines the version of each artifact:
- Each property should follow the standard naming convention of "version.groupId.artifactId"