### PR TITLE
Create ConfigMap for test namespace fixes #6867

### DIFF
--- a/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/kubernetes/SessionListener.java
+++ b/components/fabric8-arquillian/src/main/java/io/fabric8/arquillian/kubernetes/SessionListener.java
@@ -96,6 +96,7 @@ public class SessionListener {
 
         if (configuration.isCreateNamespaceForTest()) {
             createNamespace(client, controller, session);
+            updateConfigMapStatus(client, session, Constants.RUNNING_STATUS);
         } else {
             String namespaceToUse = configuration.getNamespace();
             checkNamespace(client, controller, session, configuration);


### PR DESCRIPTION
A `fabric8-arquillian` ConfigMap should be created in the SessionListener when the `create.namespace.for.test` property is true