### PR TITLE
OSFUSE-619: do not define a scope in generated BOMs

### DIFF
--- a/custom-bom.xml.vm
+++ b/custom-bom.xml.vm
@@ -70,9 +70,7 @@
             <dependency>
                 <groupId>${d.groupId}</groupId>
                 <artifactId>${d.artifactId}</artifactId>
-                <version>#[[$]]#{version.${d.groupId}.${d.artifactId}}</version>#if( $d.scope && $!d.scope != '' )
-
-                <scope>${d.scope}</scope>#end#if( $d.type && $!d.type != '' && $!d.type != 'jar' && $!d.type != 'bundle')
+                <version>#[[$]]#{version.${d.groupId}.${d.artifactId}}</version>#if( $d.type && $!d.type != '' && $!d.type != 'jar' && $!d.type != 'bundle')
 
                 <type>${d.type}</type>#end#if( $d.classifier && $!d.classifier != '' )
 


### PR DESCRIPTION
It may lead to weird issues (e.g. having test libraries into the final fat jar).