### PR TITLE
Resolved issue-6969

### DIFF
--- a/components/fabric8-project-utils/src/test/java/io/fabric8/project/support/GitHubCloneUrlTest.java
+++ b/components/fabric8-project-utils/src/test/java/io/fabric8/project/support/GitHubCloneUrlTest.java
@@ -1,0 +1,24 @@
+package io.fabric8.project.support;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GitHubCloneUrlTest {
+
+  @Test
+  public void should_return_url_without_api() {
+    String expected = "https://github.com";
+    String address = "https://api.github.com";
+    String actual = BuildConfigHelper.resolveToRoot(address);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void should_return_url_as_it_is() {
+    String expected = "https://gogs.vgrant.f8";
+    String address = "https://gogs.vgrant.f8";
+    String actual = BuildConfigHelper.resolveToRoot(address);
+    assertEquals(expected, actual);
+  }
+}

--- a/components/fabric8-project-utils/src/test/java/io/fabric8/project/support/GitUtilsTest.java
+++ b/components/fabric8-project-utils/src/test/java/io/fabric8/project/support/GitUtilsTest.java
@@ -20,6 +20,8 @@ import org.eclipse.jgit.lib.Repository;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -29,13 +31,40 @@ import static org.junit.Assert.assertNotNull;
 public class GitUtilsTest {
     @Test
     public void testGetRepositoryURL() throws Exception {
-        File basedir = new File(System.getProperty("basedir", "."));
-        Repository repository = GitUtils.findRepository(basedir);
-        assertNotNull("Should find a repository", repository);
+        Repository repository = assertRepos();
 
         String url = GitUtils.getRemoteURL(repository);
         System.out.println("Found git repository URL: " + url);
         assertThat(url).isNotEmpty().contains(".git");
+    }
+
+    private Repository assertRepos() throws IOException {
+        File basedir = new File(System.getProperty("basedir", "."));
+        Repository repository = GitUtils.findRepository(basedir);
+        assertNotNull("Should find a repository", repository);
+        return repository;
+    }
+
+    @Test
+    public void testGetRepositoryHttpsURL() throws Exception {
+        Pattern GITHUB_HTTPS_URL_PATTERN = Pattern.compile("^https://github\\.com/(?<user>[a-z0-9](?:-?[a-z0-9]){0,38})/.*?$");
+
+        Repository repository = assertRepos();
+
+        String url = GitUtils.getRemoteAsHttpsURL(repository);
+        System.out.println("Found git repository URL: " + url);
+        assertThat(GITHUB_HTTPS_URL_PATTERN.matcher(url).find()).isTrue();
+    }
+
+    @Test
+    public void testGetRepositoryHttpsAsURLWithRemoteName() throws Exception {
+        Pattern GITHUB_HTTPS_URL_PATTERN = Pattern.compile("^https://github\\.com/(?<user>[a-z0-9](?:-?[a-z0-9]){0,38})/.*?$");
+
+        Repository repository = assertRepos();
+
+        String url = GitUtils.getRemoteAsHttpsURL(repository,"origin");
+        System.out.println("Found git repository URL: " + url);
+        assertThat(GITHUB_HTTPS_URL_PATTERN.matcher(url).find()).isTrue();
     }
 
     @Test

--- a/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GitApi.java
+++ b/components/gitrepo-api/src/main/java/io/fabric8/repo/git/GitApi.java
@@ -28,7 +28,7 @@ import java.util.List;
  * REST API for working with git hosted repositories using back ends like
  * <a href="http://gogs.io/">gogs</a> or <a href="http://github.com/">github</a>
  */
-@Path("api/v1")
+@Path("/")
 @Produces("application/json")
 @Consumes("application/json")
 public interface GitApi {


### PR DESCRIPTION
- GitApi update to accomodate GitHubAPI v3, as v2/v1 are obselete with api returning HTTP 410 gone error messages
- BuildConfigHelper updated to compute the right clone url when API address is like https://api.github.com
- Added UT for api to root address resolution

This merge is mandatory and must for https://github.com/fabric8io/fabric8-maven-plugin/issues/1081 to be merged