### PR TITLE
Update Docs-Quickstarts with links to new GitHub org

### DIFF
--- a/docs/apimanImportService.md
+++ b/docs/apimanImportService.md
@@ -6,7 +6,7 @@ Let's assume you have deployed the CxfCdi quickstart in Fabric8 using
     mvn -Pf8-deploy-local
     ...
     
-from the [ipaas-quickstarts/quickstart/cdi/cxf](https://github.com/fabric8io/ipaas-quickstarts/tree/release-v2.2.45/quickstart/cdi/cxf) directory and that you created your own organization in apiman. You can now navigate to the Organization/Service page to 'Import Services' into apiman. Apiman will obtain a list of running services in your namespace that match your search string. Use '*' to match all service. 
+from the [fabric8-quickstarts/cdi-cxf](https://github.com/fabric8-quickstarts/cdi-cxf) directory and that you created your own organization in apiman. You can now navigate to the Organization/Service page to 'Import Services' into apiman. Apiman will obtain a list of running services in your namespace that match your search string. Use '*' to match all service. 
 
 ![service import](images/apiman-serviceimport.png).
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -24,7 +24,11 @@ The following projects are for [Microservices Platform](http://fabric8.io/guide/
 The following projects are for [Fabric8 iPaaS](http://fabric8.io/guide/ipaas.html):
 
 * [fabric8-ipaas](https://github.com/fabric8io/fabric8-ipaas) contains the main [iPaaS](http://fabric8.io/guide/ipaas.html) applications
-* [ipaas-quickstarts](https://github.com/fabric8io/ipaas-quickstarts) contains the [quickstarts](http://fabric8.io/guide/quickstarts/index.html) and [archetypes](http://fabric8.io/guide/quickstarts/archetypes.html) for the [iPaaS](http://fabric8.io/guide/ipaas.html)
+* [ipaas-quickstarts](https://github.com/fabric8io/ipaas-quickstarts) contains the Maven [archetypes](quickstarts/archetypes.html) that developers can use to create new projects based on the [fabric8-quickstarts](https://github.com/fabric8-quickstarts)
+
+### Quickstarts
+
+The [fabric8-quickstarts](https://github.com/fabric8-quickstarts) GitHub organization contains example projects to make getting started with fabric8 easy. See the [quickstarts](quickstarts/index.html) documentation for more information.
 
 ### Tools
 

--- a/docs/quickstarts/archetypes.md
+++ b/docs/quickstarts/archetypes.md
@@ -1,6 +1,6 @@
 ### Archetypes
 
-For each quickstart a dedicate archetype is available. You can create
+For each quickstart a dedicated Maven archetype is available. You can create
 a new project based on the archetype easily:
 
     mvn archetype:generate \

--- a/docs/quickstarts/index.md
+++ b/docs/quickstarts/index.md
@@ -1,8 +1,8 @@
 ## Fabric8 Quickstarts
 
 Fabric8 ships with a set of quickstarts which shows you how to build a
-docker image and run it on Kubernetes / OpenShift. All quickstart can
-either run directly by checking it out from the
+docker image and run it on Kubernetes / OpenShift. A quickstart can
+either be run directly by checking it out from the
 [fabric8-quickstarts GitHub organization](https://github.com/fabric8-quickstarts)
 or run as an archetype.
 
@@ -58,13 +58,13 @@ The following quickstarts are available:
   * **wildfly** demonstrates how to deploy a simple Application as war
     on a Wildfly instance
 
-You can use this quickstarts either as an [archetype](archetypes.md)
-or directly by checking it out from the
+You can use these quickstarts either as an [archetype](archetypes.md)
+or directly by checking one out from the
 [https://github.com/fabric8-quickstarts](https://github.com/fabric8-quickstarts)
 GitHub organization.
 
-Detailed instruction for running the quickstarts can be found in an
-each section ["Running Quickstarts"](running.md)
+Detailed instructions for running the quickstarts can be found in the
+["Running Quickstarts"](running.md) section.
 
 
 

--- a/docs/quickstarts/index.md
+++ b/docs/quickstarts/index.md
@@ -3,7 +3,7 @@
 Fabric8 ships with a set of quickstarts which shows you how to build a
 docker image and run it on Kubernetes / OpenShift. All quickstart can
 either run directly by checking it out from the
-[ipaas-quickstarts GitHub project](https://github.com/fabric8io/ipaas-quickstarts)
+[fabric8-quickstarts GitHub organization](https://github.com/fabric8-quickstarts)
 or run as an archetype.
 
 
@@ -12,7 +12,7 @@ First time users of fabric8 may enjoy a [walk through](walkthrough.md) a simple 
 
 The following quickstarts are available:
 
-* [CDI](https://github.com/fabric8io/ipaas-quickstarts/tree/master/quickstart/cdi)
+* [CDI](https://github.com/fabric8-quickstarts?q=cdi)
   quickstarts using standalone Java container with CDI injected
   components
   * **camel** shows how to work with Camel in the Java container using CDI.
@@ -22,7 +22,7 @@ The following quickstarts are available:
     from a Camel CDI application. 
   * **cxf** - shows how to work with CXF in the Java Container using
     CDI to configure CXF REST services. 
-* [Java](https://github.com/fabric8io/ipaas-quickstarts/tree/master/quickstart/java)
+* [Java](https://github.com/fabric8-quickstarts?q=java)
   quickstarts using standalone plain Java container 
   * **camel-spring** demonstrates how to run a Spring based Camel
     application as a standalone Java container. The Camel route is
@@ -31,11 +31,11 @@ The following quickstarts are available:
     Container using your custom main class as a FAT jar. 
   * **simple-mainclass** this example shows how to start the Java
     Container using your custom main class as a main class.
-* [Karaf](https://github.com/fabric8io/ipaas-quickstarts/tree/master/quickstart/karaf) 
+* [Karaf](https://github.com/fabric8-quickstarts?q=karaf) 
   quickstarts using Apache Karaf containers.
   * **camel-amq** demonstrates using Apache Camel to send and recieve
     messages to an Apache ActiveMQ message broker, using the Camel
-    [amq](https://github.com/fabric8io/fabric8/tree/master/components/mq/camel-amq)
+    [amq](https://github.com/fabric8io/fabric8-ipaas/tree/master/camel-amq)
     component. 
   * **camel-log** is a beginner example using Apache Camel that logs a
     message every 5th second. 
@@ -43,11 +43,11 @@ The following quickstarts are available:
     Camel's REST DSL to expose a RESTful API. 
   * **cxf-rest** is a set of web service and REST examples using
     Apache CXF. 
-* [Spring Boot](https://github.com/fabric8io/ipaas-quickstarts/tree/master/quickstart/spring-boot) 
+* [Spring Boot](https://github.com/fabric8-quickstarts?q=spring-boot) 
   quickstarts 
   * **camel** demonstrates how you can use Apache Camel with Spring Boot.
   * **webmvc** demonstrates how you can use Spring MVC with Spring Boot.
-* [War](https://github.com/fabric8io/ipaas-quickstarts/tree/master/quickstart/war)
+* [War](https://github.com/fabric8-quickstarts?q=war%20OR%20wildfly)
   quickstarts are using Java Servlet containers, supporting WAR deployments.
   * **camel-servlet** demonstrates how you can use Servlet to expose a
     http service in a Camel route, and run that in a servlet container
@@ -59,9 +59,9 @@ The following quickstarts are available:
     on a Wildfly instance
 
 You can use this quickstarts either as an [archetype](archetypes.md)
-or directly by checking out the
-[https://github.com/fabric8io/ipaas-quickstarts](https://github.com/fabric8io/ipaas-quickstarts)
-project.
+or directly by checking it out from the
+[https://github.com/fabric8-quickstarts](https://github.com/fabric8-quickstarts)
+GitHub organization.
 
 Detailed instruction for running the quickstarts can be found in an
 each section ["Running Quickstarts"](running.md)

--- a/docs/quickstarts/running.md
+++ b/docs/quickstarts/running.md
@@ -92,7 +92,7 @@ the option `-Dfabric8.dockerUser` to specify your username:
  
     mvn clean install docker:build docker:push -Dfabric8.dockerUser=morlock/
 
-(Pleade note the trailing `/` after the username). Authentication for this user *morlock* must 
+(Please note the trailing `/` after the username). Authentication for this user *morlock* must 
 be done as described in the [manual for the docker-maven-plugin](https://github.com/rhuss/docker-maven-plugin). 
 E.g. you can use `-Ddocker.push.username` and `-Ddocker.push.password` for specifying the
 credentials or you can set this up in your `~/.m2/settings.xml`.

--- a/docs/quickstarts/running.md
+++ b/docs/quickstarts/running.md
@@ -12,14 +12,14 @@ You can run one of the [quickstarts](index.md) either directly out of
 a git checked out repository or from a project created by an
 quickstart [archetype](archetype.md).
 
-The quickstarts can be used directly by
+The quickstarts can be used directly by checking one out from the
+[fabric8-quickstarts](https://github.com/fabric8-quickstarts) GitHub organization.
+For example:
 
-    git clone https://github.com/fabric8io/ipaas-quickstarts.git
-    cd quickstart
+    git clone https://github.com/fabric8-quickstarts/cdi-camel.git
+    cd cdi-camel
 
-and then into the subdirectory of a specific quickstart.
-
-For the rest of this chapter we are using `cdi/camel` as an example
+For the rest of this chapter we are using `cdi-camel` as an example
 and assume that you are within its directory.
 
 #### Check your environment

--- a/docs/quickstarts/walkthrough.md
+++ b/docs/quickstarts/walkthrough.md
@@ -20,14 +20,8 @@ In this guide we will start with one of the simplest which is the `java-fatjar` 
 
 To get started you can checkout the quickstart source code using the following git command:
 
-    git clone https://github.com/fabric8io/ipaas-quickstarts.git
-    cd ipaas-quickstarts
-
-And then change directory to 
-
-    cd quickstart
-    cd java
-    cd fatjar
+    git clone https://github.com/fabric8-quickstarts/java-fatjar.git
+    cd java-fatjar
     
  
 #### Check your environment
@@ -172,7 +166,7 @@ Which will clean and compile the source, do a docker image build, and re-deploy 
 When the application is de-deployed then kubernetes will shutdown the old pod, and start a new pod, so we will list all the running pods with `oc get pods`:
 
 ```
-ipaas-quickstarts/quickstart/java/fatjar/$ oc get pods
+java-fatjar/$ oc get pods
 NAME                                  READY     STATUS    RESTARTS   AGE
 docker-registry-1-68nz6               1/1       Running   0          15m
 fabric8-jccyj                         1/1       Running   0          16m
@@ -188,7 +182,7 @@ And as you can see the pod name has changed to `java-fatjar-2nnx7`. To see our c
 And you should see our changed logging message:
 
 ```
-ipaas-quickstarts/quickstart/java/fatjar/$ oc logs -f java-fatjar-2nnx7
+java-fatjar/$ oc logs -f java-fatjar-2nnx7
 I> No access restrictor found, access to all MBean is allowed
 Jolokia: Agent started with URL http://172.17.0.7:8778/jolokia/
 I was here: PorTM


### PR DESCRIPTION
Update hyperlinks in the Quickstart documentation to point to the new GitHub organization fabric8-quickstarts.

Fixes #6762 