### PR TITLE
Updated back to 3gb because 4 gb exceeds the maximum limit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('github.com/fabric8io/fabric8-pipeline-library@master')
 def dummy
 clientsTemplate{
-  mavenNode(mavenOpts: "-Xmx4096m") {
+  mavenNode(mavenOpts: "-Xmx3072m") {
     ws{
       checkout scm
       sh "git remote set-url origin git@github.com:fabric8io/fabric8.git"


### PR DESCRIPTION
https://jenkins.cd.test.fabric8.io/job/fabric8io/job/fabric8/job/master/17/console

Invalid maximum heap size: -Xmx4096m
The specified size exceeds the maximum representable size.
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.